### PR TITLE
Backup errored workout

### DIFF
--- a/lib/data_models/FE_data_models/exercise_data_models.dart
+++ b/lib/data_models/FE_data_models/exercise_data_models.dart
@@ -13,15 +13,16 @@ class GeneralExerciseModel {
   // final MuscleGroupType secondaryMuscleGroup;
   final List<GeneralExerciseSetModel> exerciseSets;
 
-  GeneralExerciseModel({this.id,
-    this.exerciseOrder,
-    required this.movementName,
-    required this.movementId,
-    this.exerciseDuration,
-    this.numWorkingSets,
-    required this.primaryMuscleGroup,
-    // required this.secondaryMuscleGroup,
-    required this.exerciseSets});
+  GeneralExerciseModel(
+      {this.id,
+      this.exerciseOrder,
+      required this.movementName,
+      required this.movementId,
+      this.exerciseDuration,
+      this.numWorkingSets,
+      required this.primaryMuscleGroup,
+      // required this.secondaryMuscleGroup,
+      required this.exerciseSets});
 }
 
 // ===================================
@@ -59,7 +60,7 @@ class LoadedExerciseModel {
       exerciseDuration: map['exercise_duration'],
       numWorkingSets: map['num_working_sets'],
       primaryMuscleGroup:
-      MuscleGroupType.values.byName(map['primary_muscle_group_name']),
+          MuscleGroupType.values.byName(map['primary_muscle_group_name']),
       // secondaryMuscleGroup: secondaryMuscleGroup,
       exerciseSets: [],
     );
@@ -93,14 +94,15 @@ class NewExerciseModel {
   // final MuscleGroupType secondaryMuscleGroup;
   final List<NewExerciseSetModel> exerciseSets;
 
-  NewExerciseModel({this.exerciseOrder,
-    required this.movementName,
-    this.movementId,
-    this.exerciseDuration,
-    this.numWorkingSets,
-    required this.primaryMuscleGroup,
-    // required this.secondaryMuscleGroup,
-    required this.exerciseSets});
+  NewExerciseModel(
+      {this.exerciseOrder,
+      required this.movementName,
+      this.movementId,
+      this.exerciseDuration,
+      this.numWorkingSets,
+      required this.primaryMuscleGroup,
+      // required this.secondaryMuscleGroup,
+      required this.exerciseSets});
 
   GeneralExerciseModel transformToGeneralModel() {
     GeneralExerciseModel convertedModel = GeneralExerciseModel(
@@ -109,7 +111,8 @@ class NewExerciseModel {
         movementId: movementId,
         numWorkingSets: numWorkingSets,
         primaryMuscleGroup: primaryMuscleGroup,
-        exerciseSets: exerciseSets.map((exerciseSets) => exerciseSets.transformToGeneralModel())
+        exerciseSets: exerciseSets
+            .map((exerciseSets) => exerciseSets.transformToGeneralModel())
             .toList());
 
     return convertedModel;
@@ -123,9 +126,25 @@ class NewExerciseModel {
       'exerciseDuration': exerciseDuration,
       'numWorkingSets': numWorkingSets,
       'primaryMuscleGroup': primaryMuscleGroup.toString().split(".").last,
-      'exerciseSets': exerciseSets.map((exerciseSet) => exerciseSet.toMap()).toList()
+      'exerciseSets':
+          exerciseSets.map((exerciseSet) => exerciseSet.toMap()).toList()
     };
 
     return modelAsMap;
+  }
+
+  factory NewExerciseModel.fromJson(Map<String, dynamic> json) {
+    return NewExerciseModel(
+      exerciseOrder: json['exerciseOrder'],
+      movementName: json['movementName'],
+      movementId: json['movementId'],
+      exerciseDuration: json['exerciseDuration'],
+      numWorkingSets: json['numWorkingSets'],
+      primaryMuscleGroup:
+          MuscleGroupType.values.byName(json['primaryMuscleGroup']),
+      exerciseSets: (json['exerciseSets'] as List)
+          .map((setJson) => NewExerciseSetModel.fromJson(setJson))
+          .toList(),
+    );
   }
 }

--- a/lib/data_models/FE_data_models/exercise_data_models.dart
+++ b/lib/data_models/FE_data_models/exercise_data_models.dart
@@ -114,4 +114,18 @@ class NewExerciseModel {
 
     return convertedModel;
   }
+
+  Map<String, dynamic> toMap() {
+    Map<String, dynamic> modelAsMap = {
+      'exerciseOrder': exerciseOrder,
+      'movementName': movementName,
+      'movementId': movementId,
+      'exerciseDuration': exerciseDuration,
+      'numWorkingSets': numWorkingSets,
+      'primaryMuscleGroup': primaryMuscleGroup.toString().split(".").last,
+      'exerciseSets': exerciseSets.map((exerciseSet) => exerciseSet.toMap()).toList()
+    };
+
+    return modelAsMap;
+  }
 }

--- a/lib/data_models/FE_data_models/exercise_set_data_models.dart
+++ b/lib/data_models/FE_data_models/exercise_set_data_models.dart
@@ -112,4 +112,16 @@ class NewExerciseSetModel {
 
     return modelAsMap;
   }
+
+  factory NewExerciseSetModel.fromJson(Map<String, dynamic> json) {
+    return NewExerciseSetModel(
+      exerciseSetOrder: json['exerciseSetOrder'],
+      isWarmUp: json['isWarmUp'],
+      weight: json['weight'],
+      reps: json['reps'],
+      extraReps: json['extraReps'],
+      setDuration: json['setDuration'],
+      notes: json['notes'],
+    );
+  }
 }

--- a/lib/data_models/FE_data_models/exercise_set_data_models.dart
+++ b/lib/data_models/FE_data_models/exercise_set_data_models.dart
@@ -98,4 +98,18 @@ class NewExerciseSetModel {
 
     return convertedModel;
   }
+
+  Map<String, dynamic> toMap() {
+    Map<String, dynamic> modelAsMap = {
+      'exerciseSetOrder': exerciseSetOrder,
+      'isWarmUp': isWarmUp,
+      'weight': weight,
+      'reps': reps,
+      'extraReps': extraReps,
+      'setDuration': setDuration,
+      'notes': notes,
+    };
+
+    return modelAsMap;
+  }
 }

--- a/lib/data_models/FE_data_models/workout_data_models.dart
+++ b/lib/data_models/FE_data_models/workout_data_models.dart
@@ -42,4 +42,17 @@ class NewWorkoutModel extends GeneralWorkoutModel {
       super.workoutStartTime,
       super.workoutDuration,
       required this.exercises});
+
+  Map<String, dynamic> toMap() {
+    Map<String, dynamic> modelAsMap = {
+      'day': day,
+      'month': month,
+      'year': year,
+      'workoutStartTime': workoutStartTime,
+      'workoutDuration': workoutDuration,
+      'exercises': exercises.map((exercise) => exercise.toMap()).toList()
+    };
+
+    return modelAsMap;
+  }
 }

--- a/lib/design/routing/pages/home_page.dart
+++ b/lib/design/routing/pages/home_page.dart
@@ -105,7 +105,7 @@ class HomePage extends StatelessWidget {
                 alignment: const Alignment(0, 0.8),
                 child: const NewWorkoutButton()),
           ]),
-          floatingActionButton: true ?
+          floatingActionButton: false ?
               const LoadErroredWorkoutButton() : null,
         ),
       ),

--- a/lib/design/routing/pages/home_page.dart
+++ b/lib/design/routing/pages/home_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gym_bro/design/widgets/home_page_widgets/continue_workout_button_widget.dart';
+import 'package:gym_bro/design/widgets/home_page_widgets/load_errored_workout_button_widget.dart';
 import 'package:gym_bro/design/widgets/the_app_bar_widget.dart';
 import 'package:gym_bro/state_management/blocs/database_tables/exercise/exercise_table_operations_bloc.dart';
 import 'package:gym_bro/state_management/blocs/database_tables/exercise/exercise_table_operations_event.dart';
@@ -13,8 +14,6 @@ import 'package:gym_bro/state_management/blocs/database_tables/workout/workout_t
 import 'package:gym_bro/state_management/blocs/database_tables/workout/workout_table_operations_state.dart';
 import 'package:gym_bro/state_management/cubits/active_workout_cubit/active_workout_cubit.dart';
 import 'package:gym_bro/state_management/cubits/active_workout_cubit/active_workout_state.dart';
-import 'package:gym_bro/state_management/cubits/save_error_state_cubit/save_error_state_cubit.dart';
-import 'package:gym_bro/state_management/cubits/save_error_state_cubit/save_error_state_state.dart';
 
 import '../../widgets/home_page_widgets/new_workout_button_widget.dart';
 import '../../widgets/home_page_widgets/workouts_list_widget.dart';
@@ -106,24 +105,8 @@ class HomePage extends StatelessWidget {
                 alignment: const Alignment(0, 0.8),
                 child: const NewWorkoutButton()),
           ]),
-          floatingActionButton:
-              BlocBuilder<SaveErrorStateCubit, SaveErrorStateState>(
-            builder: (context, state) {
-              return FloatingActionButton(
-                onPressed: () {
-                  if (state.errorStateData.isEmpty) {
-                    BlocProvider.of<SaveErrorStateCubit>(context)
-                        .loadErrorState();
-                  }
-                },
-                backgroundColor:
-                    state.errorStateData.isNotEmpty ? Colors.red : null,
-                child: state.errorStateData.isNotEmpty
-                    ? const Icon(Icons.file_download_sharp)
-                    : const Icon(Icons.add),
-              );
-            },
-          ),
+          floatingActionButton: true ?
+              const LoadErroredWorkoutButton() : null,
         ),
       ),
     );

--- a/lib/design/routing/pages/home_page.dart
+++ b/lib/design/routing/pages/home_page.dart
@@ -13,6 +13,8 @@ import 'package:gym_bro/state_management/blocs/database_tables/workout/workout_t
 import 'package:gym_bro/state_management/blocs/database_tables/workout/workout_table_operations_state.dart';
 import 'package:gym_bro/state_management/cubits/active_workout_cubit/active_workout_cubit.dart';
 import 'package:gym_bro/state_management/cubits/active_workout_cubit/active_workout_state.dart';
+import 'package:gym_bro/state_management/cubits/save_error_state_cubit/save_error_state_cubit.dart';
+import 'package:gym_bro/state_management/cubits/save_error_state_cubit/save_error_state_state.dart';
 
 import '../../widgets/home_page_widgets/new_workout_button_widget.dart';
 import '../../widgets/home_page_widgets/workouts_list_widget.dart';
@@ -104,6 +106,24 @@ class HomePage extends StatelessWidget {
                 alignment: const Alignment(0, 0.8),
                 child: const NewWorkoutButton()),
           ]),
+          floatingActionButton:
+              BlocBuilder<SaveErrorStateCubit, SaveErrorStateState>(
+            builder: (context, state) {
+              return FloatingActionButton(
+                onPressed: () {
+                  if (state.errorStateData.isEmpty) {
+                    BlocProvider.of<SaveErrorStateCubit>(context)
+                        .loadErrorState();
+                  }
+                },
+                backgroundColor:
+                    state.errorStateData.isNotEmpty ? Colors.red : null,
+                child: state.errorStateData.isNotEmpty
+                    ? const Icon(Icons.file_download_sharp)
+                    : const Icon(Icons.add),
+              );
+            },
+          ),
         ),
       ),
     );

--- a/lib/design/widgets/home_page_widgets/load_errored_workout_button_widget.dart
+++ b/lib/design/widgets/home_page_widgets/load_errored_workout_button_widget.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gym_bro/state_management/cubits/active_workout_cubit/active_workout_cubit.dart';
+import 'package:gym_bro/state_management/cubits/save_error_state_cubit/save_error_state_cubit.dart';
+import 'package:gym_bro/state_management/cubits/save_error_state_cubit/save_error_state_state.dart';
+
+class LoadErroredWorkoutButton extends StatelessWidget {
+  const LoadErroredWorkoutButton({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<SaveErrorStateCubit, SaveErrorStateState>(
+      builder: (context, state) {
+        return FloatingActionButton(
+          onPressed: () {
+            if (state.errorStateData.isEmpty) {
+              BlocProvider.of<SaveErrorStateCubit>(context)
+                  .loadErrorState();
+            } else {
+              BlocProvider.of<ActiveWorkoutCubit>(context).loadErroredWorkoutToState(state.errorStateData);
+            }
+          },
+          backgroundColor:
+          state.errorStateData.isNotEmpty ? Colors.red : null,
+          child: state.errorStateData.isNotEmpty
+              ? const Icon(Icons.file_download_sharp)
+              : const Icon(Icons.add),
+        );
+      },
+    );
+  }
+}

--- a/lib/design/widgets/home_page_widgets/new_workout_button_widget.dart
+++ b/lib/design/widgets/home_page_widgets/new_workout_button_widget.dart
@@ -3,6 +3,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gym_bro/state_management/blocs/database_tables/exercise/exercise_table_operations_bloc.dart';
 import 'package:gym_bro/state_management/blocs/database_tables/exercise/exercise_table_operations_event.dart';
 import 'package:gym_bro/state_management/cubits/active_workout_cubit/active_workout_cubit.dart';
+import 'package:gym_bro/state_management/cubits/set_timer_cubit/set_timer_cubit.dart';
+import 'package:gym_bro/state_management/cubits/workout_timer_cubit/workout_timer_cubit.dart';
 
 class NewWorkoutButton extends StatelessWidget {
   const NewWorkoutButton({
@@ -15,6 +17,8 @@ class NewWorkoutButton extends StatelessWidget {
     return TextButton(
       onPressed: () {
         BlocProvider.of<ActiveWorkoutCubit>(context).createNewWorkoutState();
+        BlocProvider.of<WorkoutTimerCubit>(context).resetTimer();
+        BlocProvider.of<SetTimerCubit>(context).resetTimer();
         BlocProvider.of<ExerciseTableOperationsBloc>(context).add(ResetExerciseQueryEvent());
         Navigator.of(context).pushNamed("/workout-page");
       },

--- a/lib/design/widgets/workout_page_widgets/completed_exercises_scaffold/finish_workout_button_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/completed_exercises_scaffold/finish_workout_button_widget.dart
@@ -49,7 +49,7 @@ class FinishWorkoutButton extends StatelessWidget {
                         try {
                           BlocProvider.of<WorkoutTimerCubit>(context)
                               .stopTimer();
-                          // throw Exception("testing snackbar");
+                          BlocProvider.of<ActiveWorkoutCubit>(context).updateNewWorkoutDuration(timerState.toString());
                           BlocProvider.of<WorkoutTableOperationsBloc>(context)
                               .add(
                             InsertNewWorkoutIntoTableEvent(
@@ -58,13 +58,12 @@ class FinishWorkoutButton extends StatelessWidget {
                                 month: month,
                                 year: year,
                                 workoutStartTime: workoutStartTime,
-                                workoutDuration: timerState.elapsed == 0
-                                    ? null
-                                    : timerState.toString(),
+                                workoutDuration: (workoutState as NewActiveWorkoutState).workoutDuration,
                                 exercises: exercises,
                               ),
                             ),
                           );
+                          throw Exception("TESTING");
                           BlocProvider.of<WorkoutTimerCubit>(context)
                               .resetTimer();
                           BlocProvider.of<WorkoutTableOperationsBloc>(context)
@@ -76,7 +75,7 @@ class FinishWorkoutButton extends StatelessWidget {
                           ScaffoldMessenger.of(context).showSnackBar(
                             SnackBar(
                               content: Text(
-                                  'An error occurred while adding workout to database: $e'),
+                                  'An error occurred while adding workout to database:\n$e'),
                               backgroundColor: Colors.red,
                             ),
                           );

--- a/lib/design/widgets/workout_page_widgets/completed_exercises_scaffold/finish_workout_button_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/completed_exercises_scaffold/finish_workout_button_widget.dart
@@ -5,6 +5,8 @@ import 'package:gym_bro/data_models/FE_data_models/workout_data_models.dart';
 import 'package:gym_bro/state_management/blocs/database_tables/workout/workout_table_operations_bloc.dart';
 import 'package:gym_bro/state_management/blocs/database_tables/workout/workout_table_operations_event.dart';
 import 'package:gym_bro/state_management/cubits/active_workout_cubit/active_workout_cubit.dart';
+import 'package:gym_bro/state_management/cubits/active_workout_cubit/active_workout_state.dart';
+import 'package:gym_bro/state_management/cubits/save_error_state_cubit/save_error_state_cubit.dart';
 import 'package:gym_bro/state_management/cubits/workout_timer_cubit/workout_timer_cubit.dart';
 import 'package:gym_bro/state_management/cubits/workout_timer_cubit/workout_timer_state.dart';
 
@@ -38,34 +40,59 @@ class FinishWorkoutButton extends StatelessWidget {
           aspectRatio: 1,
           child: BlocBuilder<WorkoutTimerCubit, WorkoutTimerState>(
             builder: (timerContext, timerState) {
-              return TextButton(
-                  onPressed: exercises.isNotEmpty
-                      ? () {
+              return BlocBuilder<ActiveWorkoutCubit, ActiveWorkoutState>(
+                builder: (workoutContext, workoutState) {
+                  return TextButton(
+                      onPressed: exercises.isEmpty
+                          ? null
+                          : () {
+                        try {
                           BlocProvider.of<WorkoutTimerCubit>(context)
                               .stopTimer();
+                          // throw Exception("testing snackbar");
                           BlocProvider.of<WorkoutTableOperationsBloc>(context)
-                              .add(InsertNewWorkoutIntoTableEvent(
-                                  newWorkout: NewWorkoutModel(
-                                      day: day,
-                                      month: month,
-                                      year: year,
-                                      workoutStartTime: workoutStartTime,
-                                      workoutDuration: timerState.elapsed == 0
-                                          ? null
-                                          : timerState.toString(),
-                                      exercises: exercises)));
+                              .add(
+                            InsertNewWorkoutIntoTableEvent(
+                              newWorkout: NewWorkoutModel(
+                                day: day,
+                                month: month,
+                                year: year,
+                                workoutStartTime: workoutStartTime,
+                                workoutDuration: timerState.elapsed == 0
+                                    ? null
+                                    : timerState.toString(),
+                                exercises: exercises,
+                              ),
+                            ),
+                          );
                           BlocProvider.of<WorkoutTimerCubit>(context)
                               .resetTimer();
                           BlocProvider.of<WorkoutTableOperationsBloc>(context)
                               .add(QueryAllWorkoutTableEvent());
-                          BlocProvider.of<ActiveWorkoutCubit>(context).resetState();
+                          BlocProvider.of<ActiveWorkoutCubit>(context)
+                              .resetState();
                           Navigator.of(context).pushNamed("/");
+                        } catch (e) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(
+                                  'An error occurred while adding workout to database: $e'),
+                              backgroundColor: Colors.red,
+                            ),
+                          );
+                          NewActiveWorkoutState currentState = workoutState as NewActiveWorkoutState;
+                          BlocProvider.of<SaveErrorStateCubit>(context)
+                              .writeErrorState(currentState.newWorkoutToMap());
+                          // Handle error here
+                          print("An error occurred: $e");
                         }
-                      : null,
-                  child: const Icon(
-                    Icons.check_box,
-                    size: 50,
-                  ));
+                      },
+                      child: const Icon(
+                        Icons.check_box,
+                        size: 50,
+                      ));
+                },
+              );
             },
           ),
         ),

--- a/lib/design/widgets/workout_page_widgets/completed_exercises_scaffold/finish_workout_button_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/completed_exercises_scaffold/finish_workout_button_widget.dart
@@ -49,7 +49,6 @@ class FinishWorkoutButton extends StatelessWidget {
                         try {
                           BlocProvider.of<WorkoutTimerCubit>(context)
                               .stopTimer();
-                          BlocProvider.of<ActiveWorkoutCubit>(context).updateNewWorkoutDuration(timerState.toString());
                           BlocProvider.of<WorkoutTableOperationsBloc>(context)
                               .add(
                             InsertNewWorkoutIntoTableEvent(
@@ -58,12 +57,11 @@ class FinishWorkoutButton extends StatelessWidget {
                                 month: month,
                                 year: year,
                                 workoutStartTime: workoutStartTime,
-                                workoutDuration: (workoutState as NewActiveWorkoutState).workoutDuration,
+                                workoutDuration: (workoutState as NewActiveWorkoutState).workoutDuration ?? timerState.toString(),
                                 exercises: exercises,
                               ),
                             ),
                           );
-                          throw Exception("TESTING");
                           BlocProvider.of<WorkoutTimerCubit>(context)
                               .resetTimer();
                           BlocProvider.of<WorkoutTableOperationsBloc>(context)
@@ -81,7 +79,7 @@ class FinishWorkoutButton extends StatelessWidget {
                           );
                           NewActiveWorkoutState currentState = workoutState as NewActiveWorkoutState;
                           BlocProvider.of<SaveErrorStateCubit>(context)
-                              .writeErrorState(currentState.newWorkoutToMap());
+                              .writeErrorState(currentState.newWorkoutToMap(), timerState.toString());
                           // Handle error here
                           print("An error occurred: $e");
                         }

--- a/lib/design/widgets/workout_page_widgets/workout_date_timer_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/workout_date_timer_widget.dart
@@ -34,6 +34,9 @@ class WorkoutDateTimer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (!isLoadedWorkout && workoutDuration != null) {
+      BlocProvider.of<WorkoutTimerCubit>(context).setTimer(workoutDuration!);
+    }
     return Container(
       color: Colors.black12,
       child: SizedBox(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:gym_bro/state_management/blocs/database_tables/movement/movement
 import 'package:gym_bro/state_management/cubits/active_workout_cubit/active_workout_cubit.dart';
 import 'package:gym_bro/state_management/cubits/add_exercise_cubit/add_exercise_cubit.dart';
 import 'package:gym_bro/state_management/cubits/open_exercise_modal_cubit/open_exercise_modal_cubit.dart';
+import 'package:gym_bro/state_management/cubits/save_error_state_cubit/save_error_state_cubit.dart';
 import 'package:gym_bro/state_management/cubits/set_timer_cubit/set_timer_cubit.dart';
 import 'package:gym_bro/state_management/cubits/workout_timer_cubit/workout_timer_cubit.dart';
 
@@ -53,6 +54,7 @@ class MyApp extends StatelessWidget {
         BlocProvider(create: (context) => AddExerciseCubit()),
         BlocProvider(create: (context) => SetTimerCubit()),
         BlocProvider(create: (context) => WorkoutTimerCubit()),
+        BlocProvider(create: (context) => SaveErrorStateCubit()),
       ],
       child: MaterialApp(
         title: 'Flutter Demo',

--- a/lib/state_management/cubits/active_workout_cubit/active_workout_cubit.dart
+++ b/lib/state_management/cubits/active_workout_cubit/active_workout_cubit.dart
@@ -91,18 +91,25 @@ class ActiveWorkoutCubit extends Cubit<ActiveWorkoutState> {
       StateError("Cannot update state: $state != NewActiveWorkoutState");
     }
   }
+
   loadCompleteWorkoutToState(LoadedWorkoutModel completeWorkout) {
     // print("we loading complete workout ${completeWorkout.id} to state");
-    LoadedActiveWorkoutState completeLoadedWorkoutState = LoadedActiveWorkoutState(
-        id: completeWorkout.id,
-        day: completeWorkout.day,
-        month: completeWorkout.month,
-        year: completeWorkout.year,
-        workoutStartTime: completeWorkout.workoutStartTime,
-        workoutDuration: completeWorkout.workoutDuration,
-        exercises: completeWorkout.exercises);
+    LoadedActiveWorkoutState completeLoadedWorkoutState =
+        LoadedActiveWorkoutState(
+            id: completeWorkout.id,
+            day: completeWorkout.day,
+            month: completeWorkout.month,
+            year: completeWorkout.year,
+            workoutStartTime: completeWorkout.workoutStartTime,
+            workoutDuration: completeWorkout.workoutDuration,
+            exercises: completeWorkout.exercises);
 
     emit(completeLoadedWorkoutState);
+  }
+
+  loadErroredWorkoutToState(Map<String, dynamic> erroredWorkoutState) {
+    // print("we loading complete workout ${completeWorkout.id} to state");
+    print("loadin errored workout to state");
   }
 
   loadWorkoutToState(WorkoutTable loadedWorkout) {
@@ -129,4 +136,5 @@ class ActiveWorkoutCubit extends Cubit<ActiveWorkoutState> {
       StateError("Cannot load exercises to state: $state");
     }
   }
+
 }

--- a/lib/state_management/cubits/active_workout_cubit/active_workout_cubit.dart
+++ b/lib/state_management/cubits/active_workout_cubit/active_workout_cubit.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gym_bro/constants/enums.dart';
 import 'package:gym_bro/data_models/FE_data_models/exercise_data_models.dart';
 import 'package:gym_bro/data_models/FE_data_models/exercise_set_data_models.dart';
 import 'package:gym_bro/data_models/FE_data_models/workout_data_models.dart';
@@ -51,13 +50,15 @@ class ActiveWorkoutCubit extends Cubit<ActiveWorkoutState> {
     if (state is NewActiveWorkoutState && workoutDuration != null) {
       NewActiveWorkoutState currentState = state as NewActiveWorkoutState;
 
-      emit(NewActiveWorkoutState(
+      NewActiveWorkoutState workoutStateWithDuration = NewActiveWorkoutState(
           day: currentState.day,
           month: currentState.month,
           year: currentState.year,
           workoutStartTime: currentState.workoutStartTime,
           workoutDuration: workoutDuration,
-          exercises: currentState.exercises));
+          exercises: currentState.exercises);
+
+      emit(workoutStateWithDuration);
     }
   }
 
@@ -125,6 +126,8 @@ class ActiveWorkoutCubit extends Cubit<ActiveWorkoutState> {
         day: erroredWorkoutState['day'],
         month: erroredWorkoutState['month'],
         year: erroredWorkoutState['year'],
+        workoutStartTime: erroredWorkoutState['workoutStartTime'],
+        workoutDuration: erroredWorkoutState['workoutDuration'],
         exercises: (erroredWorkoutState['exercises'] as List<dynamic>)
             .map((exercise) => NewExerciseModel.fromJson(exercise))
             .toList());

--- a/lib/state_management/cubits/active_workout_cubit/active_workout_cubit.dart
+++ b/lib/state_management/cubits/active_workout_cubit/active_workout_cubit.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gym_bro/constants/enums.dart';
 import 'package:gym_bro/data_models/FE_data_models/exercise_data_models.dart';
 import 'package:gym_bro/data_models/FE_data_models/exercise_set_data_models.dart';
 import 'package:gym_bro/data_models/FE_data_models/workout_data_models.dart';
@@ -46,6 +47,20 @@ class ActiveWorkoutCubit extends Cubit<ActiveWorkoutState> {
     }
   }
 
+  updateNewWorkoutDuration(String? workoutDuration) {
+    if (state is NewActiveWorkoutState && workoutDuration != null) {
+      NewActiveWorkoutState currentState = state as NewActiveWorkoutState;
+
+      emit(NewActiveWorkoutState(
+          day: currentState.day,
+          month: currentState.month,
+          year: currentState.year,
+          workoutStartTime: currentState.workoutStartTime,
+          workoutDuration: workoutDuration,
+          exercises: currentState.exercises));
+    }
+  }
+
   addNewExerciseToWorkoutState(AddExerciseState newExercise) {
     if (state is NewActiveWorkoutState) {
       NewActiveWorkoutState currentState = state as NewActiveWorkoutState;
@@ -75,8 +90,6 @@ class ActiveWorkoutCubit extends Cubit<ActiveWorkoutState> {
       StateError("Cannot update state: $state != NewActiveWorkoutState");
     }
   }
-
-  addExerciseSetsToExercises() {}
 
   finishWorkout(String workoutDuration) {
     if (state is NewActiveWorkoutState &&
@@ -108,8 +121,15 @@ class ActiveWorkoutCubit extends Cubit<ActiveWorkoutState> {
   }
 
   loadErroredWorkoutToState(Map<String, dynamic> erroredWorkoutState) {
-    // print("we loading complete workout ${completeWorkout.id} to state");
-    print("loadin errored workout to state");
+    NewActiveWorkoutState loadedState = NewActiveWorkoutState(
+        day: erroredWorkoutState['day'],
+        month: erroredWorkoutState['month'],
+        year: erroredWorkoutState['year'],
+        exercises: (erroredWorkoutState['exercises'] as List<dynamic>)
+            .map((exercise) => NewExerciseModel.fromJson(exercise))
+            .toList());
+
+    emit(loadedState);
   }
 
   loadWorkoutToState(WorkoutTable loadedWorkout) {
@@ -136,5 +156,4 @@ class ActiveWorkoutCubit extends Cubit<ActiveWorkoutState> {
       StateError("Cannot load exercises to state: $state");
     }
   }
-
 }

--- a/lib/state_management/cubits/active_workout_cubit/active_workout_state.dart
+++ b/lib/state_management/cubits/active_workout_cubit/active_workout_state.dart
@@ -55,6 +55,19 @@ class NewActiveWorkoutState extends ActiveWorkoutOnState {
     );
   }
 
+  newWorkoutToMap() {
+      Map<String, dynamic> modelAsMap = {
+        'day': day,
+        'month': month,
+        'year': year,
+        'workoutStartTime': workoutStartTime,
+        'workoutDuration': workoutDuration,
+        'exercises': exercises.map((exercise) => exercise.toMap()).toList()
+      };
+
+      return modelAsMap;
+    }
+
   @override
   List<Object?> get props => [...super.props, workoutDuration, exercises];
 }

--- a/lib/state_management/cubits/save_error_state_cubit/save_error_state_cubit.dart
+++ b/lib/state_management/cubits/save_error_state_cubit/save_error_state_cubit.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gym_bro/state_management/cubits/save_error_state_cubit/save_error_state_state.dart';
+import 'package:path_provider/path_provider.dart';
+
+class SaveErrorStateCubit extends Cubit<SaveErrorStateState> {
+  SaveErrorStateCubit() : super(const SaveErrorStateState());
+
+  collectErrorState(Map<String, dynamic> erroredWorkoutMap) {
+    emit(SaveErrorStateState(errorStateData: erroredWorkoutMap));
+  }
+
+  writeErrorState(Map<String, dynamic> erroredWorkoutMap) async {
+    Directory rootDirectory = await getApplicationDocumentsDirectory();
+    File errorStateFile =
+        File('${rootDirectory.path}/error_state/saved_error_state.json');
+    Map<String, dynamic> stateData = {'errorStateData': erroredWorkoutMap};
+
+    await Directory('${rootDirectory.path}/error_state')
+        .create(recursive: true);
+
+    await errorStateFile.writeAsString(json.encode(stateData));
+
+    print('saved at ${errorStateFile.path}');
+  }
+
+  loadErrorState() async {
+    Directory rootDirectory = await getApplicationDocumentsDirectory();
+
+    Directory errorStateDirectory =
+        Directory("${rootDirectory.path}/error_state");
+
+    File errorStateFile =
+        File("${errorStateDirectory.path}/saved_error_state.json");
+
+    if (await errorStateDirectory.exists() && await errorStateFile.exists()) {
+      try {
+        String jsonString = await errorStateFile.readAsString();
+
+        Map<String, dynamic> jsonAsMap = jsonDecode(jsonString);
+
+        emit(SaveErrorStateState(errorStateData: jsonAsMap));
+      } catch (err) {
+        print("there was an error retrieving the saved data state: $err");
+      }
+    }
+  }
+}

--- a/lib/state_management/cubits/save_error_state_cubit/save_error_state_cubit.dart
+++ b/lib/state_management/cubits/save_error_state_cubit/save_error_state_cubit.dart
@@ -12,7 +12,12 @@ class SaveErrorStateCubit extends Cubit<SaveErrorStateState> {
     emit(SaveErrorStateState(errorStateData: erroredWorkoutMap));
   }
 
-  writeErrorState(Map<String, dynamic> erroredWorkoutMap) async {
+  writeErrorState(
+      Map<String, dynamic> erroredWorkoutMap, String? workoutDuration) async {
+    if (workoutDuration != null && erroredWorkoutMap['workoutDuration'] == null) {
+      erroredWorkoutMap['workoutDuration'] = workoutDuration;
+    }
+
     Directory rootDirectory = await getApplicationDocumentsDirectory();
     File errorStateFile =
         File('${rootDirectory.path}/error_state/saved_error_state.json');

--- a/lib/state_management/cubits/save_error_state_cubit/save_error_state_cubit.dart
+++ b/lib/state_management/cubits/save_error_state_cubit/save_error_state_cubit.dart
@@ -16,7 +16,7 @@ class SaveErrorStateCubit extends Cubit<SaveErrorStateState> {
     Directory rootDirectory = await getApplicationDocumentsDirectory();
     File errorStateFile =
         File('${rootDirectory.path}/error_state/saved_error_state.json');
-    Map<String, dynamic> stateData = {'errorStateData': erroredWorkoutMap};
+    Map<String, dynamic> stateData = erroredWorkoutMap;
 
     await Directory('${rootDirectory.path}/error_state')
         .create(recursive: true);

--- a/lib/state_management/cubits/save_error_state_cubit/save_error_state_state.dart
+++ b/lib/state_management/cubits/save_error_state_cubit/save_error_state_state.dart
@@ -1,7 +1,7 @@
 import 'package:equatable/equatable.dart';
 
 class SaveErrorStateState extends Equatable {
-  final Map errorStateData;
+  final Map<String, dynamic> errorStateData;
 
   const SaveErrorStateState({this.errorStateData = const {}});
 

--- a/lib/state_management/cubits/save_error_state_cubit/save_error_state_state.dart
+++ b/lib/state_management/cubits/save_error_state_cubit/save_error_state_state.dart
@@ -1,0 +1,10 @@
+import 'package:equatable/equatable.dart';
+
+class SaveErrorStateState extends Equatable {
+  final Map errorStateData;
+
+  const SaveErrorStateState({this.errorStateData = const {}});
+
+  @override
+  List<Object?> get props => [errorStateData];
+}

--- a/lib/state_management/cubits/workout_timer_cubit/workout_timer_cubit.dart
+++ b/lib/state_management/cubits/workout_timer_cubit/workout_timer_cubit.dart
@@ -42,4 +42,16 @@ class WorkoutTimerCubit extends Cubit<WorkoutTimerState> {
         emit(WorkoutTimerStarted(state.elapsed + 1));
     }
   }
+
+  setTimer(String alreadyElapsedString) {
+    List<String> splitDuration = alreadyElapsedString.split(":");
+
+    int hoursElapsed = int.parse(splitDuration.first) * 3600;
+    int minutesElapsed = int.parse(splitDuration.elementAt(1)) * 60;
+    int secondsElapsed = int.parse(splitDuration.last);
+
+    int totalSecondsElapsed = hoursElapsed + minutesElapsed + secondsElapsed;
+
+    emit(WorkoutTimerStopped(totalSecondsElapsed));
+  }
 }


### PR DESCRIPTION
This PR introduced a method to debug errored workouts without loosing them completely. 

Currently, if the user attempts to save a completed workout and it fails, for whatever reason, the user will be returned to the home screen and the workout will be lost.

With this PR the user will not be directed to the home screen if there is a failure, instead a snackbar will pop up at the bottom of the screen indicating that there was an error saving the workout to the database, and displaying that error. The workout will then be saved in json format locally.

When the user loads up the app again (or returns to the home screen) the load errored workout button can be enabled, this will load up the errored workout from the json file and load it into the ActiveWorkoutState allowing the workout to be debugged and hopefully saved to the database.