### PR TITLE
[Hotfix] Reconfigured steps for inserting workout into database.

### DIFF
--- a/lib/design/widgets/workout_page_widgets/completed_exercises_scaffold/finish_workout_button_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/completed_exercises_scaffold/finish_workout_button_widget.dart
@@ -6,7 +6,6 @@ import 'package:gym_bro/state_management/blocs/database_tables/workout/workout_t
 import 'package:gym_bro/state_management/blocs/database_tables/workout/workout_table_operations_event.dart';
 import 'package:gym_bro/state_management/cubits/active_workout_cubit/active_workout_cubit.dart';
 import 'package:gym_bro/state_management/cubits/active_workout_cubit/active_workout_state.dart';
-import 'package:gym_bro/state_management/cubits/save_error_state_cubit/save_error_state_cubit.dart';
 import 'package:gym_bro/state_management/cubits/workout_timer_cubit/workout_timer_cubit.dart';
 import 'package:gym_bro/state_management/cubits/workout_timer_cubit/workout_timer_state.dart';
 
@@ -46,44 +45,26 @@ class FinishWorkoutButton extends StatelessWidget {
                       onPressed: exercises.isEmpty
                           ? null
                           : () {
-                        try {
-                          BlocProvider.of<WorkoutTimerCubit>(context)
-                              .stopTimer();
-                          BlocProvider.of<WorkoutTableOperationsBloc>(context)
-                              .add(
-                            InsertNewWorkoutIntoTableEvent(
-                              newWorkout: NewWorkoutModel(
-                                day: day,
-                                month: month,
-                                year: year,
-                                workoutStartTime: workoutStartTime,
-                                workoutDuration: (workoutState as NewActiveWorkoutState).workoutDuration ?? timerState.toString(),
-                                exercises: exercises,
-                              ),
-                            ),
-                          );
-                          BlocProvider.of<WorkoutTimerCubit>(context)
-                              .resetTimer();
-                          BlocProvider.of<WorkoutTableOperationsBloc>(context)
-                              .add(QueryAllWorkoutTableEvent());
-                          BlocProvider.of<ActiveWorkoutCubit>(context)
-                              .resetState();
-                          Navigator.of(context).pushNamed("/");
-                        } catch (e) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(
-                              content: Text(
-                                  'An error occurred while adding workout to database:\n$e'),
-                              backgroundColor: Colors.red,
-                            ),
-                          );
-                          NewActiveWorkoutState currentState = workoutState as NewActiveWorkoutState;
-                          BlocProvider.of<SaveErrorStateCubit>(context)
-                              .writeErrorState(currentState.newWorkoutToMap(), timerState.toString());
-                          // Handle error here
-                          print("An error occurred: $e");
-                        }
-                      },
+                              BlocProvider.of<WorkoutTimerCubit>(context)
+                                  .stopTimer();
+                              BlocProvider.of<WorkoutTableOperationsBloc>(
+                                      context)
+                                  .add(
+                                InsertNewWorkoutIntoTableEvent(
+                                  newWorkout: NewWorkoutModel(
+                                    day: day,
+                                    month: month,
+                                    year: year,
+                                    workoutStartTime: workoutStartTime,
+                                    workoutDuration:
+                                        (workoutState as NewActiveWorkoutState)
+                                                .workoutDuration ??
+                                            timerState.toString(),
+                                    exercises: exercises,
+                                  ),
+                                ),
+                              );
+                            },
                       child: const Icon(
                         Icons.check_box,
                         size: 50,

--- a/lib/state_management/blocs/database_tables/workout/workout_table_operations_bloc.dart
+++ b/lib/state_management/blocs/database_tables/workout/workout_table_operations_bloc.dart
@@ -15,8 +15,7 @@ class WorkoutTableOperationsBloc
       WorkoutTableOperationsEvent event) async* {
     if (event is QueryAllWorkoutTableEvent) {
       yield* _mapLoadContextsToState(event);
-    }
-    else if (event is InsertNewWorkoutIntoTableEvent) {
+    } else if (event is InsertNewWorkoutIntoTableEvent) {
       yield* _mapInsertContextsToState(event);
     }
   }
@@ -28,8 +27,7 @@ class WorkoutTableOperationsBloc
       // movementRepository.inspectSchema();
       var query = await workoutRepository.getAllWorkouts();
       yield WorkoutTableSuccessfulQueryAllState(allWorkoutsQuery: query);
-    }
-    catch (e) {
+    } catch (e) {
       print("Whoops.. we've got reached a WorkoutTableQueryErrorState\n$e");
       yield WorkoutTableQueryErrorState();
     }
@@ -40,10 +38,10 @@ class WorkoutTableOperationsBloc
     try {
       await workoutRepository.insertNewFullWorkout(event.newWorkout);
       yield WorkoutTableSuccessfulNewWorkoutInsertState();
-    }
-    catch (e) {
+    } catch (e) {
       print("Whoops.. we've got reached a WorkoutTableInsertErrorState\n$e");
-      yield WorkoutTableInsertErrorState();
+      yield WorkoutTableInsertErrorState(
+          error: e, insertWorkout: event.newWorkout);
     }
   }
 }

--- a/lib/state_management/blocs/database_tables/workout/workout_table_operations_state.dart
+++ b/lib/state_management/blocs/database_tables/workout/workout_table_operations_state.dart
@@ -47,4 +47,9 @@ class WorkoutTableSuccessfulInsertState extends WorkoutTableInsertState {}
 class WorkoutTableSuccessfulNewWorkoutInsertState
     extends WorkoutTableSuccessfulInsertState {}
 
-class WorkoutTableInsertErrorState extends WorkoutTableInsertState {}
+class WorkoutTableInsertErrorState extends WorkoutTableInsertState {
+  final Object error;
+  final NewWorkoutModel insertWorkout;
+
+  WorkoutTableInsertErrorState({required this.error, required this.insertWorkout});
+}

--- a/lib/state_management/cubits/save_error_state_cubit/save_error_state_cubit.dart
+++ b/lib/state_management/cubits/save_error_state_cubit/save_error_state_cubit.dart
@@ -12,12 +12,7 @@ class SaveErrorStateCubit extends Cubit<SaveErrorStateState> {
     emit(SaveErrorStateState(errorStateData: erroredWorkoutMap));
   }
 
-  writeErrorState(
-      Map<String, dynamic> erroredWorkoutMap, String? workoutDuration) async {
-    if (workoutDuration != null && erroredWorkoutMap['workoutDuration'] == null) {
-      erroredWorkoutMap['workoutDuration'] = workoutDuration;
-    }
-
+  writeErrorState(Map<String, dynamic> erroredWorkoutMap) async {
     Directory rootDirectory = await getApplicationDocumentsDirectory();
     File errorStateFile =
         File('${rootDirectory.path}/error_state/saved_error_state.json');


### PR DESCRIPTION
### Reconfigured steps for inserting workout into database.

Before, when a workout was inserted into a database, all the logic and steps existed within the `FinishWorkoutButton`. 
From inserting the data to reseting the timer, page rooting and handling errors with inserting data into the database.

The problem with this is that due to the method to insert data into the database being part of a Bloc, the errors are handled by producing an Error state, which is not picked up by a try/catch block. 

Instead ,the FinishWorkoutButton only stops the workout timer and sends off the `InsertNewWorkoutIntoTableEvent` after-which a `BlocListener` on the `WorkoutPage` handles the steps after, depending on the state emitted from the Bloc