### PR TITLE
[PATCH] Fixed Bug in Add new movement functionality

### DIFF
--- a/lib/data_models/database_data_models/tables/workout/workout_repository.dart
+++ b/lib/data_models/database_data_models/tables/workout/workout_repository.dart
@@ -20,10 +20,11 @@ class WorkoutRepository {
   }
 
   insertNewMovement(NewExerciseModel newMovementExercise, txn) async {
+    String lowerCaseMovementName = newMovementExercise.movementName.toLowerCase();
     // first we check to see if the movement does exist in the db
     String queryString = """
     SELECT id FROM $movementTableName
-    WHERE name = '${newMovementExercise.movementName.toLowerCase()}';
+    WHERE name = '$lowerCaseMovementName';
     """;
     final List<Map<String, dynamic>> existingMovementId =
         await txn.rawQuery(queryString);
@@ -32,7 +33,7 @@ class WorkoutRepository {
     // if the movement doesn't exist we need to insert it
     String insertNewMovementString = """
     INSERT INTO $movementTableName (name) VALUES
-      ('${newMovementExercise.movementName.toLowerCase()}');
+      ('$lowerCaseMovementName');
     """;
     final newMovementId = await txn.rawInsert(insertNewMovementString);
 

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/exercise_selector_cluster/row3_exercise_selector_and_timer_sub-widgets/add_new_movement_expanding_widget_sub-widgets/add_new_movement_name_sub-widgets.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/exercise_selector_cluster/row3_exercise_selector_and_timer_sub-widgets/add_new_movement_expanding_widget_sub-widgets/add_new_movement_name_sub-widgets.dart
@@ -44,7 +44,7 @@ class AddNewMovementNameTextField extends StatelessWidget {
           ),
           onSubmitted: (String inputText) {
             BlocProvider.of<AddNewMovementCubit>(context)
-                .typeMovementName(inputText.trim());
+                .typeMovementName(inputText.trim().toLowerCase());
           },
         ));
   }

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/exercise_selector_cluster/row3_exercise_selector_and_timer_sub-widgets/exercise_selector_container_sub-widgets/exercise_dropdown_menu_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/exercise_selector_cluster/row3_exercise_selector_and_timer_sub-widgets/exercise_selector_container_sub-widgets/exercise_dropdown_menu_widget.dart
@@ -58,21 +58,24 @@ class ExerciseDropdownMenu extends StatelessWidget {
               onSelected: (value) {
                 final int? movementId;
 
-                if (value != addMovementValue) {
-                  movementId = value.movementId;
-                  BlocProvider.of<AddExerciseCubit>(context)
-                      .selectExercise(value);
-                  BlocProvider.of<AddNewMovementCubit>(context)
-                      .closeAddNewMovementExpansionPanel();
-                } else {
+                if (value == addMovementValue) {
                   movementId = null;
                   BlocProvider.of<AddExerciseCubit>(context)
                       .selectMuscleGroup(selectedMuscleGroup!);
+                  BlocProvider.of<GetLastExerciseSetsByMovementBloc>(context)
+                      .add(ResetGetLastExerciseSetsByMovementEvent());
                   BlocProvider.of<AddNewMovementCubit>(context)
                       .openAddNewMovementExpansionPanel();
+                } else {
+                  movementId = value.movementId;
+                  BlocProvider.of<AddExerciseCubit>(context)
+                      .selectExercise(value);
+                  BlocProvider.of<GetLastExerciseSetsByMovementBloc>(context)
+                      .add(QueryLastExerciseSetsByMovementEvent(
+                      movementId: movementId));
+                  BlocProvider.of<AddNewMovementCubit>(context)
+                      .closeAddNewMovementExpansionPanel();
                 }
-                BlocProvider.of<GetLastExerciseSetsByMovementBloc>(context).add(QueryLastExerciseSetsByMovementEvent(
-                movementId: movementId));
               },
             );
           default:


### PR DESCRIPTION
Removed query to database for new movements and reset state `.add(ResetGetLastExerciseSetsByMovementEvent());` 
for them

BEFORE:
```
if (value != addMovementValue) {
  movementId = value.movementId;
  BlocProvider.of<AddExerciseCubit>(context)
      .selectExercise(value);
  BlocProvider.of<AddNewMovementCubit>(context)
      .closeAddNewMovementExpansionPanel();
} else {
  movementId = null;
  BlocProvider.of<AddExerciseCubit>(context)
     .selectMuscleGroup(selectedMuscleGroup!);
  BlocProvider.of<AddNewMovementCubit>(context)
      .openAddNewMovementExpansionPanel();
}

BlocProvider.of<GetLastExerciseSetsByMovementBloc>(context).add(
  QueryLastExerciseSetsByMovementEvent(movementId: movementId)
);
```

AFTER:
```
if (value != addMovementValue) {
  movementId = value.movementId;
  BlocProvider.of<AddExerciseCubit>(context)
      .selectExercise(value);
  BlocProvider.of<GetLastExerciseSetsByMovementBloc>(context).add(
    QueryLastExerciseSetsByMovementEvent(movementId: movementId)
  );
  BlocProvider.of<AddNewMovementCubit>(context)
      .closeAddNewMovementExpansionPanel();
} else {
  movementId = null;
  BlocProvider.of<AddExerciseCubit>(context)
     .selectMuscleGroup(selectedMuscleGroup!);
  BlocProvider.of<GetLastExerciseSetsByMovementBloc>(context)
      .add(ResetGetLastExerciseSetsByMovementEvent());
  BlocProvider.of<AddNewMovementCubit>(context)
      .openAddNewMovementExpansionPanel();
}

```
