### PR TITLE
Current Workout Backup Functionality

### DIFF
--- a/lib/design/routing/pages/home_page.dart
+++ b/lib/design/routing/pages/home_page.dart
@@ -15,6 +15,8 @@ import 'package:gym_bro/state_management/blocs/database_tables/workout/workout_t
 import 'package:gym_bro/state_management/blocs/database_tables/workout/workout_table_operations_state.dart';
 import 'package:gym_bro/state_management/cubits/active_workout_cubit/active_workout_cubit.dart';
 import 'package:gym_bro/state_management/cubits/active_workout_cubit/active_workout_state.dart';
+import 'package:gym_bro/state_management/cubits/backup_current_workout_cubit/backup_current_workout_cubit.dart';
+import 'package:gym_bro/state_management/cubits/backup_current_workout_cubit/backup_current_workout_state.dart';
 
 import '../../widgets/home_page_widgets/new_workout_button_widget.dart';
 import '../../widgets/home_page_widgets/workouts_list_widget.dart';
@@ -72,6 +74,25 @@ class HomePage extends StatelessWidget {
             }
           },
         ),
+        BlocListener<BackupCurrentWorkoutCubit, BackupCurrentWorkoutState>(
+            listener: (context, state) {
+          if (state.backupWorkoutData.isNotEmpty) {
+            BlocProvider.of<ActiveWorkoutCubit>(context)
+                .loadSavedJsonWorkoutToState(state.backupWorkoutData);
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Center(
+                  child: Text(
+                    'Resuming the backed up workout',
+                    style: TextStyle(color: Colors.black),
+                  ),
+                ),
+                backgroundColor: Colors.blue,
+              ),
+            );
+            Navigator.of(context).pushNamed("/workout-page");
+          }
+        })
       ],
       child: Scaffold(
         appBar: const TheAppBar(

--- a/lib/design/widgets/home_page_widgets/load_errored_workout_button_widget.dart
+++ b/lib/design/widgets/home_page_widgets/load_errored_workout_button_widget.dart
@@ -16,14 +16,13 @@ class LoadErroredWorkoutButton extends StatelessWidget {
         return FloatingActionButton(
           onPressed: () {
             if (state.errorStateData.isEmpty) {
-              BlocProvider.of<SaveErrorStateCubit>(context)
-                  .loadErrorState();
+              BlocProvider.of<SaveErrorStateCubit>(context).loadErrorState();
             } else {
-              BlocProvider.of<ActiveWorkoutCubit>(context).loadErroredWorkoutToState(state.errorStateData);
+              BlocProvider.of<ActiveWorkoutCubit>(context)
+                  .loadSavedJsonWorkoutToState(state.errorStateData);
             }
           },
-          backgroundColor:
-          state.errorStateData.isNotEmpty ? Colors.red : null,
+          backgroundColor: state.errorStateData.isNotEmpty ? Colors.red : null,
           child: state.errorStateData.isNotEmpty
               ? const Icon(Icons.file_download_sharp)
               : const Icon(Icons.add),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,6 +20,7 @@ import 'data_models/database_data_models/tables/workout/workout_repository.dart'
 import 'state_management/blocs/database_tables/exercise/exercise_table_operations_bloc.dart';
 import 'state_management/blocs/database_tables/exercise_set/exercise_set_table_operations_bloc.dart';
 import 'state_management/blocs/database_tables/workout/workout_table_operations_bloc.dart';
+import 'state_management/cubits/backup_current_workout_cubit/backup_current_workout_cubit.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -66,6 +67,7 @@ class MyApp extends StatelessWidget {
         BlocProvider(create: (context) => WorkoutTimerCubit()),
         BlocProvider(create: (context) => DisplayPrCubit()),
         BlocProvider(create: (context) => AddNewMovementCubit()),
+        BlocProvider(create: (context) => BackupCurrentWorkoutCubit()..loadBackupState()),
         BlocProvider(create: (context) => SaveErrorStateCubit()),
       ],
       child: MaterialApp(

--- a/lib/state_management/cubits/active_workout_cubit/active_workout_cubit.dart
+++ b/lib/state_management/cubits/active_workout_cubit/active_workout_cubit.dart
@@ -109,14 +109,14 @@ class ActiveWorkoutCubit extends Cubit<ActiveWorkoutState> {
     emit(completeLoadedWorkoutState);
   }
 
-  loadErroredWorkoutToState(Map<String, dynamic> erroredWorkoutState) {
+  loadSavedJsonWorkoutToState(Map<String, dynamic> savedJsonWorkoutState) {
     NewActiveWorkoutState loadedState = NewActiveWorkoutState(
-        day: erroredWorkoutState['day'],
-        month: erroredWorkoutState['month'],
-        year: erroredWorkoutState['year'],
-        workoutStartTime: erroredWorkoutState['workoutStartTime'],
-        workoutDuration: erroredWorkoutState['workoutDuration'],
-        exercises: (erroredWorkoutState['exercises'] as List<dynamic>)
+        day: savedJsonWorkoutState['day'],
+        month: savedJsonWorkoutState['month'],
+        year: savedJsonWorkoutState['year'],
+        workoutStartTime: savedJsonWorkoutState['workoutStartTime'],
+        workoutDuration: savedJsonWorkoutState['workoutDuration'],
+        exercises: (savedJsonWorkoutState['exercises'] as List<dynamic>)
             .map((exercise) => NewExerciseModel.fromJson(exercise))
             .toList());
 

--- a/lib/state_management/cubits/backup_current_workout_cubit/backup_current_workout_cubit.dart
+++ b/lib/state_management/cubits/backup_current_workout_cubit/backup_current_workout_cubit.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:path_provider/path_provider.dart';
+
+import 'backup_current_workout_state.dart';
+
+class BackupCurrentWorkoutCubit extends Cubit<BackupCurrentWorkoutState> {
+  BackupCurrentWorkoutCubit() : super(const BackupCurrentWorkoutState());
+
+  collectErrorState(Map<String, dynamic> backupWorkoutData) {
+    emit(BackupCurrentWorkoutState(backupWorkoutData: backupWorkoutData));
+  }
+
+  writeCurrentWorkoutState(Map<String, dynamic> backupWorkoutData) async {
+    Directory rootDirectory = await getApplicationDocumentsDirectory();
+    File backupFile =
+    File('${rootDirectory.path}/backup_state/backup_workout_state.json');
+    Map<String, dynamic> stateData = backupWorkoutData;
+
+    try {
+      await Directory('${rootDirectory.path}/backup_state')
+          .create(recursive: true);
+
+      await backupFile.writeAsString(json.encode(stateData));
+
+      print('backup saved at ${backupFile.path}');
+    }
+    catch (err) {
+      print("there was an error backing up current workout: $err");
+      emit(BackupCurrentWorkoutErrorState(error: err));
+
+    }
+  }
+
+  clearBackedUpWorkout() async {
+    Directory rootDirectory = await getApplicationDocumentsDirectory();
+    File backupFile = File('${rootDirectory.path}/backup_state/backup_workout_state.json');
+
+    try {
+      if (await backupFile.exists()) {
+        await backupFile.delete();
+        print("successfully deleted backup file");
+      }
+    } catch (err) {
+        print("error in wiping backup workout: $err");
+        emit(BackupCurrentWorkoutErrorState(error: err));
+    }
+
+  }
+
+  loadBackupState() async {
+    print("Retrieving backup workout.");
+    Directory rootDirectory = await getApplicationDocumentsDirectory();
+
+    Directory backupStateDirectory =
+    Directory("${rootDirectory.path}/backup_state");
+
+    File backupStateFile =
+    File("${backupStateDirectory.path}/backup_workout_state.json");
+
+    if (await backupStateDirectory.exists() && await backupStateFile.exists()) {
+      try {
+        String jsonString = await backupStateFile.readAsString();
+
+        Map<String, dynamic> jsonAsMap = jsonDecode(jsonString);
+
+        emit(BackupCurrentWorkoutState(backupWorkoutData: jsonAsMap));
+      } catch (err) {
+        emit(BackupCurrentWorkoutErrorState(error: err));
+        print("there was an error retrieving the backed up data state: $err");
+      }
+    } else {
+      emit(const BackupCurrentWorkoutState());
+    }
+  }
+}

--- a/lib/state_management/cubits/backup_current_workout_cubit/backup_current_workout_state.dart
+++ b/lib/state_management/cubits/backup_current_workout_cubit/backup_current_workout_state.dart
@@ -1,0 +1,20 @@
+import 'package:equatable/equatable.dart';
+
+class BackupCurrentWorkoutState extends Equatable {
+  final Map<String, dynamic> backupWorkoutData;
+
+  const BackupCurrentWorkoutState({this.backupWorkoutData = const {}});
+
+  @override
+  List<Object?> get props => [backupWorkoutData];
+}
+
+class BackupCurrentWorkoutErrorState extends BackupCurrentWorkoutState {
+  final Object error;
+
+  const BackupCurrentWorkoutErrorState(
+      {super.backupWorkoutData, required this.error});
+
+  @override
+  List<Object?> get props => [super.backupWorkoutData, error];
+}


### PR DESCRIPTION
This feature was introduced to save the current workout state in case of unexpected app shutdown.

Similar to the save errored state cubit, this works by saving the current workout state to a json file.
This json file is then deleted when the workout has been successfully saved to the database.

If the app is closed, or resets, during a workout, the saved current workout state file will be loaded onto the current state and then the workout page is routed to.

### improvements to make: 
Currently the workout state is saved to the file, meaning that if the user is in the middle of recording a new exercise that data will not be saved as it is only added to the active workout state once the exercise has been completed 
