### PR TITLE
Correctly splitting and displaying secondary muscle groups working sets

### DIFF
--- a/lib/data_models/FE_data_models/exercise_data_models.dart
+++ b/lib/data_models/FE_data_models/exercise_data_models.dart
@@ -1,4 +1,5 @@
 import 'package:gym_bro/constants/enums.dart';
+import 'package:gym_bro/data_models/database_data_models/joined_tables/movement-muscle_group/movement-muscle_group_methods.dart';
 import 'package:gym_bro/data_models/database_data_models/tables/exercise/exercise_table_object.dart';
 import 'exercise_set_data_models.dart';
 
@@ -254,7 +255,7 @@ class NewExerciseModel extends GeneralWorkoutPageExerciseModel {
         movementId: map['movementId'],
         exerciseOrder: map['exerciseOrder'],
         numWorkingSets: map['numWorkingSets'],
-        workedMuscleGroups: MovementWorkedMuscleGroupsType.fromMap(
+        workedMuscleGroups: MovementWorkedMuscleGroupsType.fromJsonMap(
             map: map['workedMuscleGroups']),
         movementName: map['movementName'],
         exerciseSets:

--- a/lib/data_models/FE_data_models/exercise_data_models.dart
+++ b/lib/data_models/FE_data_models/exercise_data_models.dart
@@ -92,6 +92,11 @@ class GeneralWorkoutPageExerciseModel {
     return workedMuscleGroups.getWorkingSetsPerMuscleGroup(
         muscleGroup, numWorkingSets);
   }
+
+  int calculateWorkingSetsPerMuscleGroup(MuscleGroupType muscleGroup) {
+    return workedMuscleGroups.calculateWorkingSetsPerMuscleGroup(
+        muscleGroup, numWorkingSets);
+  }
 }
 
 // This model is used to convert between a homepage exercise model
@@ -246,15 +251,16 @@ class NewExerciseModel extends GeneralWorkoutPageExerciseModel {
 
   factory NewExerciseModel.fromMap({required Map<String, dynamic> map}) {
     NewExerciseModel regeneratedModel = NewExerciseModel(
-      movementId: map['movementId'],
+        movementId: map['movementId'],
         exerciseOrder: map['exerciseOrder'],
         numWorkingSets: map['numWorkingSets'],
-        workedMuscleGroups: MovementWorkedMuscleGroupsType.fromMap(map: map['workedMuscleGroups']),
+        workedMuscleGroups: MovementWorkedMuscleGroupsType.fromMap(
+            map: map['workedMuscleGroups']),
         movementName: map['movementName'],
-        exerciseSets: map['exerciseSets'].map<GeneralExerciseSetModel>((exerciseSetMap) {
+        exerciseSets:
+            map['exerciseSets'].map<GeneralExerciseSetModel>((exerciseSetMap) {
           return GeneralExerciseSetModel.fromMap(map: exerciseSetMap);
-        }).toList()
-    );
+        }).toList());
 
     return regeneratedModel;
   }

--- a/lib/data_models/database_data_models/joined_tables/movement-muscle_group/movement-muscle_group_methods.dart
+++ b/lib/data_models/database_data_models/joined_tables/movement-muscle_group/movement-muscle_group_methods.dart
@@ -1,0 +1,127 @@
+import 'package:gym_bro/constants/enums.dart';
+import 'package:gym_bro/data_models/database_data_models/tables/table_constants.dart';
+
+class MovementWorkedMuscleGroupsType {
+  final Map<MuscleGroupType, RoleType> workedMuscleGroupsMap;
+
+  MovementWorkedMuscleGroupsType({required this.workedMuscleGroupsMap});
+
+  static Future<List<Map<String, dynamic>>>
+      queryDbForWorkedMuscleGroupsByMovementId(int movementId, db) async {
+    String queryString = """
+      SELECT 
+        $movementMuscleGroupsTableName.role as role,
+        $muscleGroupTableName.name as name
+      FROM 
+        $movementMuscleGroupsTableName
+        
+      JOIN $muscleGroupTableName
+        ON $movementMuscleGroupsTableName.muscle_group_id = $muscleGroupTableName.id
+        
+      WHERE
+        $movementMuscleGroupsTableName.movement_id = $movementId
+    """;
+
+    List<Map<String, dynamic>> result = await db.rawQuery(queryString);
+
+    return result;
+  }
+
+  // to convert map retrieved when querying muscle groups by movement id
+  factory MovementWorkedMuscleGroupsType.fromDbMap(
+      {required List<Map<String, dynamic>> dbMap}) {
+    Map<MuscleGroupType, RoleType> musclesWorked = {};
+    for (var obj in dbMap) {
+      RoleType role = RoleType.values.byName(obj['role']);
+      MuscleGroupType muscleGroup = MuscleGroupType.values.byName(obj['name']);
+
+      musclesWorked[muscleGroup] = role;
+    }
+
+    MovementWorkedMuscleGroupsType generatedMovementMovementWorkedMuscleGroups =
+        MovementWorkedMuscleGroupsType(workedMuscleGroupsMap: musclesWorked);
+
+    return generatedMovementMovementWorkedMuscleGroups;
+  }
+
+  // Pairs together the query of the movementMuscleGroups and muscleGroups table by movementId
+  // and the generation of an instance of MovementWorkedMuscleGroupsType
+  static Future<MovementWorkedMuscleGroupsType>
+      getWorkedMuscleGroupsByMovementId(int movementId, db) async {
+    List<Map<String, dynamic>> result =
+        await queryDbForWorkedMuscleGroupsByMovementId(movementId, db);
+
+    MovementWorkedMuscleGroupsType generatedMovementWorkedMuscleGroupsType =
+        MovementWorkedMuscleGroupsType.fromDbMap(dbMap: result);
+
+    return generatedMovementWorkedMuscleGroupsType;
+  }
+
+  // convert the object into a map, used mostly for saving state as json
+  Map<String, String> toMap() {
+    Map<String, String> typeAsMap = {};
+
+    for (var entry in workedMuscleGroupsMap.entries) {
+      typeAsMap[entry.key.name] = entry.value.name;
+    }
+
+    return typeAsMap;
+  }
+
+  // convert the object back from a map, used mostly for restoring state from json
+  factory MovementWorkedMuscleGroupsType.fromJsonMap(
+      {required Map<String, dynamic> map}) {
+    Map<MuscleGroupType, RoleType> workedMuscleGroupsMap = {};
+
+    for (var entry in map.entries) {
+      workedMuscleGroupsMap[MuscleGroupType.values.byName(entry.key)] =
+          RoleType.values.byName(entry.value);
+    }
+
+    return MovementWorkedMuscleGroupsType(
+        workedMuscleGroupsMap: workedMuscleGroupsMap);
+  }
+
+  // For a movement this method returns all the primary muscle groups involved
+  List<MuscleGroupType> returnPrimaryMuscleGroups() {
+    List<MuscleGroupType> primaryMuscleGroups = [];
+    for (var muscleGroup in workedMuscleGroupsMap.entries) {
+      if (muscleGroup.value == RoleType.primary) {
+        primaryMuscleGroups.add(muscleGroup.key);
+      }
+    }
+    return primaryMuscleGroups;
+  }
+
+  // For a movement this method returns all the secondary muscle groups involved
+  List<MuscleGroupType> returnSecondaryMuscleGroups() {
+    List<MuscleGroupType> primaryMuscleGroups = [];
+    for (var muscleGroup in workedMuscleGroupsMap.entries) {
+      if (muscleGroup.value == RoleType.secondary) {
+        primaryMuscleGroups.add(muscleGroup.key);
+      }
+    }
+    return primaryMuscleGroups;
+  }
+
+  int getWorkingSetsPerMuscleGroup(
+      MuscleGroupType muscleGroup, int workingSets) {
+    if (workedMuscleGroupsMap.containsKey(muscleGroup)) {
+      return workingSets;
+    }
+    return 0;
+  }
+
+  // When tallying the number of working sets per muscle group per week
+  // we want to convert all the secondary muscle groups sets into
+  int calculateWorkingSetsPerMuscleGroup(
+      MuscleGroupType muscleGroup, int workingSets) {
+    if (workedMuscleGroupsMap.containsKey(muscleGroup)) {
+      if (workedMuscleGroupsMap[muscleGroup] == RoleType.primary) {
+        return workingSets;
+      }
+      return (workingSets / 4).floor();
+    }
+    return 0;
+  }
+}

--- a/lib/data_models/database_data_models/joined_tables/movement_muscle_group_join_object.dart
+++ b/lib/data_models/database_data_models/joined_tables/movement_muscle_group_join_object.dart
@@ -1,27 +1,21 @@
-import 'package:gym_bro/constants/enums.dart';
+import 'package:gym_bro/data_models/database_data_models/joined_tables/movement-muscle_group/movement-muscle_group_methods.dart';
 
-// TODO: add all worked muscle groups.
 class MovementMuscleGroupJoin {
   final int? movementId;
   final String movementName;
-  final RoleType muscleRole;
-  final int? muscleGroupId;
-  final MuscleGroupType muscleGroupName;
+  final MovementWorkedMuscleGroupsType workedMuscleGroups;
 
-  factory MovementMuscleGroupJoin.fromMap(Map<String, dynamic> map) {
+  factory MovementMuscleGroupJoin.fromMapWithWorkedMuscleGroups(
+      Map<String, dynamic> map,
+      MovementWorkedMuscleGroupsType workedMuscleGroups) {
     return MovementMuscleGroupJoin(
-      movementId: map['movement_id'],
-      movementName: map['movement_name'],
-      muscleRole: RoleType.values.byName(map['role']),
-      muscleGroupId: map['muscle_group_id'],
-      muscleGroupName: MuscleGroupType.values.byName(map['muscle_group_name']),
-    );
+        movementId: map['movement_id'],
+        movementName: map['movement_name'],
+        workedMuscleGroups: workedMuscleGroups);
   }
 
   MovementMuscleGroupJoin(
       {required this.movementId,
       required this.movementName,
-      required this.muscleRole,
-      required this.muscleGroupId,
-      required this.muscleGroupName});
+      required this.workedMuscleGroups});
 }

--- a/lib/data_models/database_data_models/tables/exercise/exercise_table_object.dart
+++ b/lib/data_models/database_data_models/tables/exercise/exercise_table_object.dart
@@ -1,4 +1,5 @@
 import 'package:gym_bro/constants/enums.dart';
+import 'package:gym_bro/data_models/database_data_models/joined_tables/movement-muscle_group/movement-muscle_group_methods.dart';
 
 // Model to track 1-to-1 to database table
 class ExerciseTable {
@@ -65,77 +66,5 @@ class ExerciseTableWithWorkedMuscleGroups extends ExerciseTable {
   int calculateWorkingSetsPerMuscleGroup(MuscleGroupType muscleGroup) {
     return workedMuscleGroups.calculateWorkingSetsPerMuscleGroup(
         muscleGroup, numWorkingSets);
-  }
-}
-
-class MovementWorkedMuscleGroupsType {
-  final Map<MuscleGroupType, RoleType> workedMuscleGroupsMap;
-
-  MovementWorkedMuscleGroupsType({required this.workedMuscleGroupsMap});
-
-  // convert the object into a map, used mostly for saving state as json
-  Map<String, String> toMap() {
-    Map<String, String> typeAsMap = {};
-
-    for (var entry in workedMuscleGroupsMap.entries) {
-      typeAsMap[entry.key.name] = entry.value.name;
-    }
-
-    return typeAsMap;
-  }
-
-  // convert the object back from a map, used mostly for restoring state from json
-  factory MovementWorkedMuscleGroupsType.fromMap({required Map<String, dynamic> map}) {
-    Map<MuscleGroupType, RoleType> workedMuscleGroupsMap = {};
-
-    for (var entry in map.entries) {
-      workedMuscleGroupsMap[MuscleGroupType.values.byName(entry.key)] =
-          RoleType.values.byName(entry.value);
-    }
-
-    return MovementWorkedMuscleGroupsType(workedMuscleGroupsMap: workedMuscleGroupsMap);
-  }
-
-  // For a movement this method returns all the primary muscle groups involved
-  List<MuscleGroupType> returnPrimaryMuscleGroups() {
-    List<MuscleGroupType> primaryMuscleGroups = [];
-    for (var muscleGroup in workedMuscleGroupsMap.entries) {
-      if (muscleGroup.value == RoleType.primary) {
-        primaryMuscleGroups.add(muscleGroup.key);
-      }
-    }
-    return primaryMuscleGroups;
-  }
-
-  // For a movement this method returns all the secondary muscle groups involved
-  List<MuscleGroupType> returnSecondaryMuscleGroups() {
-    List<MuscleGroupType> primaryMuscleGroups = [];
-    for (var muscleGroup in workedMuscleGroupsMap.entries) {
-      if (muscleGroup.value == RoleType.secondary) {
-        primaryMuscleGroups.add(muscleGroup.key);
-      }
-    }
-    return primaryMuscleGroups;
-  }
-
-  int getWorkingSetsPerMuscleGroup(
-      MuscleGroupType muscleGroup, int workingSets) {
-    if (workedMuscleGroupsMap.containsKey(muscleGroup)) {
-        return workingSets;
-    }
-    return 0;
-  }
-
-  // When tallying the number of working sets per muscle group per week
-  // we want to convert all the secondary muscle groups sets into
-  int calculateWorkingSetsPerMuscleGroup(
-      MuscleGroupType muscleGroup, int workingSets) {
-    if (workedMuscleGroupsMap.containsKey(muscleGroup)) {
-      if (workedMuscleGroupsMap[muscleGroup] == RoleType.primary) {
-        return workingSets;
-      }
-      return (workingSets / 4).floor();
-    }
-    return 0;
   }
 }

--- a/lib/data_models/database_data_models/tables/exercise/exercise_table_object.dart
+++ b/lib/data_models/database_data_models/tables/exercise/exercise_table_object.dart
@@ -61,6 +61,11 @@ class ExerciseTableWithWorkedMuscleGroups extends ExerciseTable {
     return workedMuscleGroups.getWorkingSetsPerMuscleGroup(
         muscleGroup, numWorkingSets);
   }
+
+  int calculateWorkingSetsPerMuscleGroup(MuscleGroupType muscleGroup) {
+    return workedMuscleGroups.calculateWorkingSetsPerMuscleGroup(
+        muscleGroup, numWorkingSets);
+  }
 }
 
 class MovementWorkedMuscleGroupsType {
@@ -91,6 +96,7 @@ class MovementWorkedMuscleGroupsType {
     return MovementWorkedMuscleGroupsType(workedMuscleGroupsMap: workedMuscleGroupsMap);
   }
 
+  // For a movement this method returns all the primary muscle groups involved
   List<MuscleGroupType> returnPrimaryMuscleGroups() {
     List<MuscleGroupType> primaryMuscleGroups = [];
     for (var muscleGroup in workedMuscleGroupsMap.entries) {
@@ -101,6 +107,7 @@ class MovementWorkedMuscleGroupsType {
     return primaryMuscleGroups;
   }
 
+  // For a movement this method returns all the secondary muscle groups involved
   List<MuscleGroupType> returnSecondaryMuscleGroups() {
     List<MuscleGroupType> primaryMuscleGroups = [];
     for (var muscleGroup in workedMuscleGroupsMap.entries) {
@@ -112,6 +119,16 @@ class MovementWorkedMuscleGroupsType {
   }
 
   int getWorkingSetsPerMuscleGroup(
+      MuscleGroupType muscleGroup, int workingSets) {
+    if (workedMuscleGroupsMap.containsKey(muscleGroup)) {
+        return workingSets;
+    }
+    return 0;
+  }
+
+  // When tallying the number of working sets per muscle group per week
+  // we want to convert all the secondary muscle groups sets into
+  int calculateWorkingSetsPerMuscleGroup(
       MuscleGroupType muscleGroup, int workingSets) {
     if (workedMuscleGroupsMap.containsKey(muscleGroup)) {
       if (workedMuscleGroupsMap[muscleGroup] == RoleType.primary) {

--- a/lib/data_models/database_data_models/tables/movement/movement_repository.dart
+++ b/lib/data_models/database_data_models/tables/movement/movement_repository.dart
@@ -1,4 +1,5 @@
 import 'package:gym_bro/constants/enums.dart';
+import 'package:gym_bro/data_models/database_data_models/joined_tables/movement-muscle_group/movement-muscle_group_methods.dart';
 import 'package:gym_bro/data_models/database_data_models/joined_tables/movement_muscle_group_join_object.dart';
 import 'package:gym_bro/data_models/database_data_models/tables/exercise/exercise_table_object.dart';
 import 'package:gym_bro/data_models/database_data_models/tables/table_constants.dart';
@@ -38,9 +39,8 @@ class MovementRepository {
     WHERE id = $movementId;
     """;
 
-    final List<Map<String, dynamic>> movementNames = await db.rawQuery(
-        queryMovementNameByIdString
-    );
+    final List<Map<String, dynamic>> movementNames =
+        await db.rawQuery(queryMovementNameByIdString);
 
     Map<String, dynamic>? movementName = movementNames.singleOrNull;
 
@@ -49,7 +49,8 @@ class MovementRepository {
     return movementName['name'];
   }
 
-  fetchAndIndexMovementNameById(List<ExerciseTableWithWorkedMuscleGroups> namelessExercises) async {
+  fetchAndIndexMovementNameById(
+      List<ExerciseTableWithWorkedMuscleGroups> namelessExercises) async {
     Map<int, String> exerciseNameIndex = {};
 
     for (ExerciseTableWithWorkedMuscleGroups exercise in namelessExercises) {
@@ -61,15 +62,16 @@ class MovementRepository {
     return exerciseNameIndex;
   }
 
-  Future<List<MovementMuscleGroupJoin>> getAllMovementsByPrimaryMuscleGroup(
-      MuscleGroupType selectedMuscleGroup) async {
-    final db = await databaseHelper.database;
-
+  Future<List<Map<String, dynamic>>> queryAllMovementsByPrimaryMuscleGroup(
+      MuscleGroupType selectedMuscleGroup, db) async {
     String dbQuery = """
         SELECT
+          $movementTableName.id AS movement_id,
           $movementTableName.name AS movement_name,
-          $muscleGroupTableName.name AS muscle_group_name,
-          *
+          
+          $muscleGroupTableName.id AS muscle_group_id,
+          $muscleGroupTableName.name AS muscle_group_name
+          
         FROM $movementTableName
 
         JOIN $movementMuscleGroupsTableName
@@ -88,8 +90,31 @@ class MovementRepository {
         """;
 
     final List<Map<String, dynamic>> movements = await db.rawQuery(dbQuery);
-    return movements
-        .map((movement) => MovementMuscleGroupJoin.fromMap(movement))
-        .toList();
+
+    return movements;
+  }
+
+  Future<List<MovementMuscleGroupJoin>> getAllMovementsByPrimaryMuscleGroup(
+      MuscleGroupType selectedMuscleGroup) async {
+    final db = await databaseHelper.database;
+
+    final List<Map<String, dynamic>> returnedMovements =
+        await queryAllMovementsByPrimaryMuscleGroup(selectedMuscleGroup, db);
+
+    List<MovementMuscleGroupJoin> movements = [];
+    for (var movementMap in returnedMovements) {
+      MovementWorkedMuscleGroupsType movementWorkedMuscleGroups =
+          await MovementWorkedMuscleGroupsType
+              .getWorkedMuscleGroupsByMovementId(
+                  movementMap['movement_id'], db);
+
+      MovementMuscleGroupJoin convertedModel =
+          MovementMuscleGroupJoin.fromMapWithWorkedMuscleGroups(
+              movementMap, movementWorkedMuscleGroups);
+
+      movements.add(convertedModel);
+    }
+
+    return movements;
   }
 }

--- a/lib/data_models/database_data_models/tables/workout/workout_object.dart
+++ b/lib/data_models/database_data_models/tables/workout/workout_object.dart
@@ -71,10 +71,8 @@ class WorkoutTableWithExercisesWorkedMuscleGroups extends WorkoutTable {
   int getNumWorkingSetsPerMuscleInWorkout(MuscleGroupType muscleGroup) {
     int totalSets = 0;
     for (ExerciseTableWithWorkedMuscleGroups exercise in exercises) {
-      totalSets += exercise.getWorkingSetsPerMuscleGroup(muscleGroup);
+      totalSets += exercise.calculateWorkingSetsPerMuscleGroup(muscleGroup);
     }
     return totalSets;
   }
-
 }
-

--- a/lib/state_management/cubits/add_exercise_cubit/add_exercise_cubit.dart
+++ b/lib/state_management/cubits/add_exercise_cubit/add_exercise_cubit.dart
@@ -2,8 +2,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gym_bro/constants/enums.dart';
 import 'package:gym_bro/data_models/FE_data_models/exercise_data_models.dart';
 import 'package:gym_bro/data_models/bloc_data_models/flutter_data_models.dart';
+import 'package:gym_bro/data_models/database_data_models/joined_tables/movement-muscle_group/movement-muscle_group_methods.dart';
 import 'package:gym_bro/data_models/database_data_models/joined_tables/movement_muscle_group_join_object.dart';
-import 'package:gym_bro/data_models/database_data_models/tables/exercise/exercise_table_object.dart';
 
 import 'add_exercise_state.dart';
 
@@ -66,7 +66,7 @@ class AddExerciseCubit extends Cubit<AddExerciseState> {
         selectedMuscleGroup: generatedState.selectedMuscleGroup,
         selectedMovement: movementMuscleGroupJoin.movementName,
         selectedMovementId: movementMuscleGroupJoin.movementId,
-        workedMuscleGroups: generatedState.workedMuscleGroups,
+        workedMuscleGroups: movementMuscleGroupJoin.workedMuscleGroups,
         currentSet: const CurrentSet(),
         setsDone: const [],
         numWorkingSets: 0));

--- a/lib/state_management/cubits/add_exercise_cubit/add_exercise_state.dart
+++ b/lib/state_management/cubits/add_exercise_cubit/add_exercise_state.dart
@@ -1,7 +1,7 @@
 import 'package:equatable/equatable.dart';
 import 'package:gym_bro/constants/enums.dart';
 import 'package:gym_bro/data_models/bloc_data_models/flutter_data_models.dart';
-import 'package:gym_bro/data_models/database_data_models/tables/exercise/exercise_table_object.dart';
+import 'package:gym_bro/data_models/database_data_models/joined_tables/movement-muscle_group/movement-muscle_group_methods.dart';
 
 class AddExerciseState extends Equatable {
   final MuscleGroupType? selectedMuscleGroup;


### PR DESCRIPTION
This PR corrects the new workout flow so that the secondary muscle groups (and other primary when applicable) used for each exercise is shown in the muscle group set counter:

### Before:
The Set counter only displays a number for the selected primary muscle group
![Screenshot 2024-08-16 at 20 06 56](https://github.com/user-attachments/assets/1b57e1b5-d4bb-42e9-8bbd-572ceb7cc77f)
### After:
The set counter shows both secondary muscle sets correctly, but also the other primary muscle group worked, as deadlifts have two primary muscle groups
![Screenshot 2024-08-16 at 20 18 03](https://github.com/user-attachments/assets/94dafce0-55c9-4545-84b4-dc622b3047d1)
(the difference in the colour for deadlifts is because deadlifts have two primary muscle groups, legs and back. Its purple purely because that muscleGroupName gets returned first in the query, this will be fixed when we introduce multi-tone tiles)
