### PR TITLE
Reprogramming the trigger to start workout timer

### DIFF
--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/exercise_selector_cluster/row3_exercise_selector_and_timer_sub-widgets/exercise_selector_container_sub-widgets/exercise_dropdown_menu_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/exercise_selector_cluster/row3_exercise_selector_and_timer_sub-widgets/exercise_selector_container_sub-widgets/exercise_dropdown_menu_widget.dart
@@ -6,6 +6,7 @@ import 'package:gym_bro/state_management/blocs/database_tables/exercise_set/get_
 import 'package:gym_bro/state_management/cubits/add_exercise_cubit/add_exercise_cubit.dart';
 import 'package:gym_bro/state_management/cubits/add_exercise_cubit/add_exercise_state.dart';
 import 'package:gym_bro/state_management/cubits/add_new_movement_cubit/add_new_movement_cubit.dart';
+import 'package:gym_bro/state_management/cubits/workout_timer_cubit/workout_timer_cubit.dart';
 
 class ExerciseDropdownMenu extends StatelessWidget {
   final List matchingExercises;
@@ -57,6 +58,8 @@ class ExerciseDropdownMenu extends StatelessWidget {
               dropdownMenuEntries: exerciseEntries,
               onSelected: (value) {
                 final int? movementId;
+                // we start the workout timer when the first exercise is selected
+                BlocProvider.of<WorkoutTimerCubit>(context).beginTimer();
 
                 if (value == addMovementValue) {
                   movementId = null;

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/exercise_selector_cluster/row3_exercise_selector_and_timer_sub-widgets/exercise_selector_container_sub-widgets/timer_button_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/exercise_selector_cluster/row3_exercise_selector_and_timer_sub-widgets/exercise_selector_container_sub-widgets/timer_button_widget.dart
@@ -4,7 +4,6 @@ import 'package:gym_bro/data_models/bloc_data_models/flutter_data_models.dart';
 import 'package:gym_bro/state_management/cubits/add_exercise_cubit/add_exercise_cubit.dart';
 import 'package:gym_bro/state_management/cubits/set_timer_cubit/set_timer_cubit.dart';
 import 'package:gym_bro/state_management/cubits/set_timer_cubit/set_timer_state.dart';
-import 'package:gym_bro/state_management/cubits/workout_timer_cubit/workout_timer_cubit.dart';
 
 class TimerButton extends StatelessWidget {
   final bool isExerciseSelected;

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/exercise_selector_cluster/row3_exercise_selector_and_timer_sub-widgets/exercise_selector_container_sub-widgets/timer_button_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/exercise_selector_cluster/row3_exercise_selector_and_timer_sub-widgets/exercise_selector_container_sub-widgets/timer_button_widget.dart
@@ -24,7 +24,6 @@ class TimerButton extends StatelessWidget {
         case SetTimerReset():
           buttonPressFunction = () {
             BlocProvider.of<SetTimerCubit>(context).startTimer();
-            BlocProvider.of<WorkoutTimerCubit>(context).startTimer();
           };
           buttonText = "Time the Set";
         case SetTimerStarted():

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/exercise_selector_cluster/row3_exercise_selector_and_timer_sub-widgets/exercise_selector_container_sub-widgets/timer_button_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/exercise_selector_cluster/row3_exercise_selector_and_timer_sub-widgets/exercise_selector_container_sub-widgets/timer_button_widget.dart
@@ -29,7 +29,9 @@ class TimerButton extends StatelessWidget {
           buttonPressFunction = () {
             BlocProvider.of<SetTimerCubit>(context).stopTimer();
             BlocProvider.of<AddExerciseCubit>(context).updateCurrentSet(
-                CurrentSet(setDuration: Duration(seconds: state.elapsed)));
+                CurrentSet(
+                    setDuration:
+                        BlocProvider.of<SetTimerCubit>(context).returnTimed()));
           };
           buttonText = "Stop Timer";
           timerColour = const Color.fromRGBO(255, 0, 0, 1);
@@ -39,7 +41,8 @@ class TimerButton extends StatelessWidget {
       }
       return TextButton(
           style: ButtonStyle(
-            side: MaterialStateProperty.all(const BorderSide(color: Colors.black, width: 1.5)),
+            side: MaterialStateProperty.all(
+                const BorderSide(color: Colors.black, width: 1.5)),
             backgroundColor: MaterialStatePropertyAll<Color>(
                 timerColour.withOpacity(isExerciseSelected ? 1 : 0.3)),
           ),
@@ -52,16 +55,14 @@ class TimerButton extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: [
                 const Icon(
-                    Icons.timer_outlined,
+                  Icons.timer_outlined,
                   color: Color.fromRGBO(230, 230, 150, 1),
                 ),
                 Text(
                   buttonText,
                   textAlign: TextAlign.center,
                   style: const TextStyle(
-                      fontSize: 12,
-                      color: Color.fromRGBO(230, 230, 150, 1)
-                  ),
+                      fontSize: 12, color: Color.fromRGBO(230, 230, 150, 1)),
                 ),
               ]));
     });

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/current_set_card/current_set_card_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/current_set_card/current_set_card_widget.dart
@@ -115,6 +115,11 @@ class CurrentSetCard extends StatelessWidget {
                         currentSet!.reps != null &&
                         currentSet!.isWarmUp != null
                     ? () {
+                        BlocProvider.of<SetTimerCubit>(context).stopTimer();
+                        BlocProvider.of<AddExerciseCubit>(context).updateCurrentSet(
+                            CurrentSet(
+                                setDuration:
+                                BlocProvider.of<SetTimerCubit>(context).returnTimed()));
                         BlocProvider.of<AddExerciseCubit>(context)
                             .saveCompletedSet();
                         BlocProvider.of<SetTimerCubit>(context).resetTimer();

--- a/lib/state_management/cubits/set_timer_cubit/set_timer_cubit.dart
+++ b/lib/state_management/cubits/set_timer_cubit/set_timer_cubit.dart
@@ -12,15 +12,17 @@ class SetTimerCubit extends Cubit<SetTimerState> {
     return Duration(seconds: state.elapsed);
   }
 
-  startTimer(){
-    emit( const SetTimerStarted(0));
+  startTimer() {
+    emit(const SetTimerStarted(0));
 
     _timer = Timer.periodic(const Duration(seconds: 1), onTick);
   }
 
   stopTimer() {
-    _timer!.cancel();
-    emit(SetTimerStopped(state.elapsed));
+    if (_timer != null) {
+      _timer!.cancel();
+      emit(SetTimerStopped(state.elapsed));
+    }
   }
 
   resetTimer() {
@@ -38,5 +40,4 @@ class SetTimerCubit extends Cubit<SetTimerState> {
         emit(SetTimerStarted(state.elapsed + 1));
     }
   }
-
 }

--- a/lib/state_management/cubits/set_timer_cubit/set_timer_cubit.dart
+++ b/lib/state_management/cubits/set_timer_cubit/set_timer_cubit.dart
@@ -8,6 +8,10 @@ class SetTimerCubit extends Cubit<SetTimerState> {
 
   Timer? _timer;
 
+  returnTimed() {
+    return Duration(seconds: state.elapsed);
+  }
+
   startTimer(){
     emit( const SetTimerStarted(0));
 

--- a/lib/state_management/cubits/workout_timer_cubit/workout_timer_cubit.dart
+++ b/lib/state_management/cubits/workout_timer_cubit/workout_timer_cubit.dart
@@ -8,6 +8,20 @@ class WorkoutTimerCubit extends Cubit<WorkoutTimerState> {
 
   Timer? _timer;
 
+  beginTimer([int? time]) {
+    switch (state) {
+      case WorkoutTimerReset():
+        if (time != null) {
+          emit(WorkoutTimerStarted(time));
+        } else {
+          emit(const WorkoutTimerStarted(0));
+        }
+        _timer = Timer.periodic(const Duration(seconds: 1), onTick);
+      default:
+        // timer already running
+    }
+  }
+
   startTimer([int? time]) {
     if (state.elapsed == 0) {
       if (time != null) {

--- a/lib/state_management/cubits/workout_timer_cubit/workout_timer_cubit.dart
+++ b/lib/state_management/cubits/workout_timer_cubit/workout_timer_cubit.dart
@@ -22,6 +22,10 @@ class WorkoutTimerCubit extends Cubit<WorkoutTimerState> {
     }
   }
 
+  returnTimed() {
+    return Duration(seconds: state.elapsed);
+  }
+
   startTimer([int? time]) {
     if (state.elapsed == 0) {
       if (time != null) {


### PR DESCRIPTION
This PR changes the trigger used to start timing the workout. 
Whereas before, the workout timer was started by the user hitting the 'time the set' button for the first time. 
This lead to not correctly capturing the actual length of the workout as if the user didn't want to time a set for whatever reason (they're not interested in the time, or the first few sets are warmup and they don't want to time them) the workout time either wouldn't be recorded or would be recorded late, leading to inconsistent/incorrect workout durations.

Now instead, the workout is timed as soon as the user first selects and exercise, this more correctly captures the length of the workout.

Additionally the bug where if the user times a set and saves it before turning the timer off, the next time the user tries to time a set, the timer ticks faster and will do for each successive set where the same case applies, compounding each time. This was handled by also adding a stop and reset timer when the user saves the set, meaning that in either case:
- the user stops the timer manually
- the user saves the set without stopping the timer

the time will be saved and the timer stopped and reset