### PR TITLE
[HotFix] Fixing misnumbered  current working set for new movements

### DIFF
--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_list_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_list_widget.dart
@@ -33,6 +33,21 @@ class SetsListContainer extends StatelessWidget {
               int? comparisonExerciseWorkingSetNumber;
               int comparisonExerciseTotalWorkingSets;
 
+              // this function prevents code duplication when calling an instance
+              // of GeneralSetContainer if comparisonSet == null or not
+              GeneralSetContainer buildGeneralSetContainer(
+                  {GeneralExerciseSetModel? comparisonSet}) {
+                return GeneralSetContainer(
+                  currentSet: currentSet!,
+                  setNumber: currentSet!.isWarmUp!
+                      ? null
+                      : completedSets.length -
+                          state.getNumberOfWarmUpSets(sets: completedSets) +
+                          1,
+                  comparisonSet: comparisonSet,
+                );
+              }
+
               if (state is SuccessfulGetLastExerciseSetsByMovementQueryState &&
                   state.lastExerciseSetsData['data'].isNotEmpty) {
                 List<GeneralExerciseSetModel> lastExerciseSets =
@@ -88,14 +103,7 @@ class SetsListContainer extends StatelessWidget {
                         GeneralSetContainer(
                             comparisonSet: comparisonSet,
                             setNumber: comparisonExerciseWorkingSetNumber),
-                        GeneralSetContainer(
-                          currentSet: currentSet!,
-                          setNumber: currentSet!.isWarmUp!
-                              ? null
-                              : completedSets.length -
-                                  state.getNumberOfWarmUpSets(
-                                      sets: completedSets) +
-                                  1,
+                        buildGeneralSetContainer(
                           comparisonSet: comparisonSet,
                         ),
                       ],
@@ -105,13 +113,7 @@ class SetsListContainer extends StatelessWidget {
               }
               // If theres no previous exercise data for this movement:
               return currentSet != null
-                  ? GeneralSetContainer(
-                      currentSet: currentSet!,
-                      setNumber: currentSet!.isWarmUp!
-                          ? null
-                          : completedSets.length -
-                              state.getNumberOfWarmUpSets(sets: completedSets),
-                    )
+                  ? buildGeneralSetContainer()
                   : Container();
             },
           ),


### PR DESCRIPTION
### Problem 
For new movements, the number listed next to the `Current Working Set:`
![Screenshot 2024-12-19 at 18 13 41](https://github.com/user-attachments/assets/7478d00d-8bb2-46c3-abee-ed2a80367d9a)
In the image the number is `0` when it should be the first set, showing the number `1`

### Reason
Simply, the logic for the current set number between the Current Set for a new movement (where `comparisonSet == null;`) was not consistent, when it should've matched.

### Solution
Added function within sets list to share code (prevent duplication) between the general models for current set for a new movement and current set for an existing movement - sharing the correct logic for the set number