### PR TITLE
Making the add exercise modal sizing more dynamic

### DIFF
--- a/lib/design/routing/pages/workout_page.dart
+++ b/lib/design/routing/pages/workout_page.dart
@@ -81,17 +81,30 @@ class WorkoutOverviewPage extends StatelessWidget {
                             default:
                               fadedValue = 0;
                           }
-                          return IgnorePointer(
-                            child: AnimatedContainer(
-                                duration: const Duration(milliseconds: 200),
-                                color: Colors.black.withOpacity(fadedValue)),
-                          );
+                          return Stack(children: [
+                            IgnorePointer(
+                              child: AnimatedContainer(
+                                  duration: const Duration(milliseconds: 100),
+                                  color: Colors.black.withOpacity(fadedValue)),
+                            ),
+                            // AddExerciseModal(isOpen: state.isOpen)
+                            Column(
+                              children: [
+                                Expanded(
+                                  flex: 10,
+                                    child:
+                                        AddExerciseModal(isOpen: state.isOpen)),
+                                SizedBox(height: 70,)
+                                // const Spacer()
+                              ],
+                            )
+                          ]);
                         },
                       ),
-                      BlocBuilder<OpenExerciseModalCubit,
-                          OpenExerciseModalState>(builder: (context, state) {
-                        return AddExerciseModal(isOpen: state.isOpen);
-                      }),
+                      // BlocBuilder<OpenExerciseModalCubit,
+                      //     OpenExerciseModalState>(builder: (context, state) {
+                      //   return AddExerciseModal(isOpen: state.isOpen);
+                      // }),
                     ]),
                   ),
                   const ExerciseCountBar()

--- a/lib/design/routing/pages/workout_page.dart
+++ b/lib/design/routing/pages/workout_page.dart
@@ -87,7 +87,6 @@ class WorkoutOverviewPage extends StatelessWidget {
                                   duration: const Duration(milliseconds: 100),
                                   color: Colors.black.withOpacity(fadedValue)),
                             ),
-                            // AddExerciseModal(isOpen: state.isOpen)
                             Column(
                               children: [
                                 Expanded(
@@ -101,10 +100,6 @@ class WorkoutOverviewPage extends StatelessWidget {
                           ]);
                         },
                       ),
-                      // BlocBuilder<OpenExerciseModalCubit,
-                      //     OpenExerciseModalState>(builder: (context, state) {
-                      //   return AddExerciseModal(isOpen: state.isOpen);
-                      // }),
                     ]),
                   ),
                   const ExerciseCountBar()

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/add_exercise_modal_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/add_exercise_modal_widget.dart
@@ -15,80 +15,102 @@ class AddExerciseModal extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return IgnorePointer(
+    return LayoutBuilder(builder: (context, constraints) {
+      print("Max height => ${constraints.maxHeight}");
+      return IgnorePointer(
         ignoring: !isOpen,
-        child: AnimatedOpacity(
-            opacity: isOpen ? 1 : 0,
-            duration: const Duration(milliseconds: 200),
-            child: SizedBox(
-              height: 800,
-              child: Stack(children: [
-                Padding(
-                  // padding: const EdgeInsets.only(bottom: 10),
-                  padding: const EdgeInsets.only(
-                      top: 12, left: 12, right: 12, bottom: 100),
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(10),
-                    child: BlocBuilder<AddExerciseCubit, AddExerciseState>(
-                      builder: (context, state) {
-                        // This is a legitimate case for state.selectedMuscleGroup
-                        // in the future this will be a mix of primary muscle group colours
-                        MuscleGroup? firstPrimaryMuscleGroup = state
-                                .workedMuscleGroups
-                                .returnPrimaryMuscleGroups()
-                                .isEmpty
-                            ? null
-                            : state.workedMuscleGroups
-                                .returnPrimaryMuscleGroups()
-                                .first;
-                        Color modalColour = firstPrimaryMuscleGroup?.colour ??
-                            const Color(0xffA9A9A9);
+        child: Padding(
+          padding:
+              const EdgeInsets.only(top: 12, left: 12, right: 12),
+          child: SingleChildScrollView(
+            clipBehavior: Clip.antiAlias,
+            child: Align(
+              alignment: Alignment.bottomLeft,
+              child: AnimatedContainer(
+                  height: !isOpen ? 0 : constraints.maxHeight - 10,
+                  duration: const Duration(milliseconds: 1500),
+                  curve: Curves.easeOutQuint,
+                  child: Stack(children: [
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(10),
+                      child: BlocBuilder<AddExerciseCubit, AddExerciseState>(
+                        builder: (context, state) {
+                          // This is a legitimate case for state.selectedMuscleGroup
+                          // in the future this will be a mix of primary muscle group colours
+                          MuscleGroup? firstPrimaryMuscleGroup = state
+                                  .workedMuscleGroups
+                                  .returnPrimaryMuscleGroups()
+                                  .isEmpty
+                              ? null
+                              : state.workedMuscleGroups
+                                  .returnPrimaryMuscleGroups()
+                                  .first;
+                          Color modalColour = firstPrimaryMuscleGroup?.colour ??
+                              const Color(0xffA9A9A9);
 
-                        return AnimatedContainer(
-                          duration: const Duration(milliseconds: 350),
-                          color: modalColour,
-                          child: Padding(
-                            padding: const EdgeInsets.all(15),
-                            child: Column(
-                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                              children: [
-                                ExerciseSelectorCluster(
-                                    selectedMuscleGroup:
-                                        firstPrimaryMuscleGroup,
-                                    workedMuscleGroups:
-                                        state.workedMuscleGroups),
-                                Expanded(
-                                  child: Padding(
-                                    padding: const EdgeInsets.symmetric(
-                                        vertical: 10.0),
-                                    child: SetsListContainer(
-                                        currentSet: state.currentSet,
-                                        completedSets: state.setsDone),
+                          return AnimatedContainer(
+                            duration: const Duration(milliseconds: 350),
+                            color: modalColour,
+                            child: Padding(
+                              padding: const EdgeInsets.all(15),
+                              child: Column(
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  ExerciseSelectorCluster(
+                                      selectedMuscleGroup:
+                                          firstPrimaryMuscleGroup,
+                                      workedMuscleGroups:
+                                          state.workedMuscleGroups),
+                                  Expanded(
+                                    child: Padding(
+                                      padding: const EdgeInsets.symmetric(
+                                          vertical: 10.0),
+                                      child: SetsListContainer(
+                                          currentSet: state.currentSet,
+                                          completedSets: state.setsDone),
+                                    ),
                                   ),
-                                ),
-                              ],
+                                ],
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                    if (true)
+                      Align(
+                        alignment: const Alignment(0, 1),
+                        child: SingleChildScrollView(
+                          scrollDirection: Axis.horizontal,
+                          child: AnimatedContainer(
+                            duration: const Duration(milliseconds: 750),
+                            curve: Curves.easeOut,
+                            width: !isOpen ? 0 : constraints.maxWidth,
+                            child: AnimatedOpacity(
+                              opacity: !isOpen ? 0 : 1,
+                              duration: const Duration(milliseconds: 500),
+                              child: const Row(
+                                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                                crossAxisAlignment: CrossAxisAlignment.end,
+                                children: [
+                                  CloseModalButton(
+                                    isFinished: false,
+                                  ),
+                                  CloseModalButton(
+                                    isFinished: true,
+                                  ),
+                                ],
+                              ),
                             ),
                           ),
-                        );
-                      },
-                    ),
-                  ),
-                ),
-                const Align(
-                  alignment: Alignment(0, 0.78),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                    children: [
-                      CloseModalButton(
-                        isFinished: false,
-                      ),
-                      CloseModalButton(
-                        isFinished: true,
-                      ),
-                    ],
-                  ),
-                )
-              ]),
-            )));
+                        ),
+                      )
+                  ])),
+            ),
+          ),
+        ),
+      );
+    });
   }
 }

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/exercise_selector_cluster/row3_exercise_selector_and_timer_sub-widgets/add_new_movement_expanding_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/exercise_selector_cluster/row3_exercise_selector_and_timer_sub-widgets/add_new_movement_expanding_widget.dart
@@ -20,11 +20,8 @@ class AddNewMovementExpandedWidget extends StatelessWidget {
           // color: const Color.fromRGBO(5, 5, 5, 0.5),
           color: const Color.fromRGBO(255, 255, 255, 0.8),
           duration: const Duration(milliseconds: 500),
-          // Duration of the animation
           curve: Curves.easeInOut,
-          // Curve for the animation
-          height: state.isNewMovementSelected ? 320 : 0,
-          // Height of the container
+          height: state.isNewMovementSelected ? null : 0,
           child: Padding(
             padding: const EdgeInsets.only(top: 10, left: 8, right: 8),
             child: AnimatedOpacity(


### PR DESCRIPTION
### Problem
Depending on the screen size of your device, the `AddNewMovementExpandingWidget` might not show in full as the exercise modal was too small and the size of the widget itself was limited

### Solution
The size of the `AddExerciseModal` needed to be changed so that it's relative size was consistent across different devices with different screen sizes. After this was fixed - providing the space required for the `AddNewMovementExpandingWidget` to fully show. The widget fits for all screen sizes 

Additionally the position of the exit exercise modal buttons were also made uniform across screen sizes, with new animations added 