### PR TITLE
Estimated 1RM

### DIFF
--- a/lib/constants/enums.dart
+++ b/lib/constants/enums.dart
@@ -67,3 +67,7 @@ enum MuscleGroupType {
   back,
   legs,
 }
+
+enum SetType { comparison, current, completed }
+
+enum TextFieldType { duration, text, number, bool }

--- a/lib/constants/utils/effective_1RM_utils.dart
+++ b/lib/constants/utils/effective_1RM_utils.dart
@@ -1,0 +1,108 @@
+// Effective 1RM class
+import 'package:gym_bro/constants/enums.dart';
+
+class Effective1RMUtils {
+  static bool showComparison1RM(
+      dynamic set, SetType setType, bool nullComparisonSet) {
+    if (set.isWarmUp || setType == SetType.comparison || nullComparisonSet) {
+      return false;
+    }
+
+    // Check for partial inputs
+    bool hasPartialInput = (set.weight == null && set.reps != null) ||
+        (set.weight != null && set.reps == null);
+
+    return hasPartialInput;
+  }
+
+  static bool showEffective1RM(dynamic set) {
+    // we only want to show the Eff 1RM if we have both weight and reps
+    if (set.isWarmUp ||
+        set.weight == null ||
+        set.reps == null ||
+        set.weight == 0) {
+      return false;
+    }
+    return true;
+  }
+
+  // Calculate Effective 1RM
+  static double? calculateEffective1RM(double? weight, int? reps) {
+    if (weight == null || reps == null) return null;
+    if (reps < 5) {
+      // Brzycki Formula
+      return weight / (1.0278 - (0.0278 * reps));
+    } else {
+      // Epley Formula
+      return weight * (1 + (0.0333 * reps));
+    }
+  }
+
+  static String? returnEffective1RM(
+      {required double weight, required int reps}) {
+    double? calculatedWeight = calculateEffective1RM(weight, reps);
+
+    if (calculatedWeight == null) return null;
+    return calculatedWeight.toStringAsFixed(2);
+  }
+
+  // Calculate Weight from Effective 1RM
+  static double calculateWeightFrom1RM(int reps, double eff1RM) {
+    if (reps < 5) {
+      // Brzycki Conversion
+      return eff1RM * (1.0278 - (0.0278 * reps));
+    } else {
+      // Epley Conversion
+      return eff1RM / (1 + (0.0333 * reps));
+    }
+  }
+
+  static String? returnCalculatedWeightFrom1RM(int? reps, double? eff1RM) {
+    if (reps == null || eff1RM == null) return null;
+
+    double calculatedWeight = calculateWeightFrom1RM(reps, eff1RM);
+
+    return calculatedWeight.toStringAsFixed(2);
+  }
+
+  // Calculate Reps from Effective 1RM
+  // TODO: needs validation step to decide if ±1 rep is better to display
+  // 1 rep under eff might be closer to eff than the returned rep
+  static double calculateRepsFrom1RM(double weight, double eff1RM) {
+    // GPT CODE:
+    // Handle invalid input
+    if (weight <= 0 || eff1RM <= 0 || weight > eff1RM) return 0;
+
+    // Calculate using both formulas
+    double brzyckiReps = (1.0278 - (eff1RM / weight)) / 0.0278;
+    double epleyReps = ((eff1RM / weight) - 1) / 0.0333;
+
+    // Return the appropriate reps based on formulas
+    double returnReps =
+    weight / eff1RM > 0.8 // Brzycki works better for heavier loads
+        ? brzyckiReps
+        : epleyReps;
+
+    // validating the calculated reps is closest to eff1RM
+    int roundedReps = returnReps.round();
+    int lowerReps = returnReps.round() - 1;
+
+    double calculatedEff1RM = calculateEffective1RM(weight, roundedReps)!;
+    double oneLessRepEff1RM = calculateEffective1RM(weight, lowerReps)!;
+
+    const double epsilon = 0.01; // Tolerance for floating-point errors
+
+    // Return the reps that give the closest effective 1RM
+    return (calculatedEff1RM - eff1RM).abs() <
+        (oneLessRepEff1RM - eff1RM).abs() + epsilon
+        ? roundedReps.toDouble()
+        : lowerReps.toDouble();
+  }
+
+  static String? returnCalculatedRepsFrom1RM(double? weight, double? eff1RM) {
+    if (weight == null || eff1RM == null) return null;
+
+    double calculatedReps = calculateRepsFrom1RM(weight, eff1RM);
+    return calculatedReps.toStringAsFixed(0);
+  }
+}

--- a/lib/constants/utils/estimated_1RM_utils.dart
+++ b/lib/constants/utils/estimated_1RM_utils.dart
@@ -1,7 +1,7 @@
 // Effective 1RM class
 import 'package:gym_bro/constants/enums.dart';
 
-class Effective1RMUtils {
+class Estimated1RMUtils {
   static bool showComparison1RM(
       dynamic set, SetType setType, bool nullComparisonSet) {
     if (set.isWarmUp || setType == SetType.comparison || nullComparisonSet) {
@@ -15,7 +15,7 @@ class Effective1RMUtils {
     return hasPartialInput;
   }
 
-  static bool showEffective1RM(dynamic set) {
+  static bool showEstimated1RM(dynamic set) {
     // we only want to show the Eff 1RM if we have both weight and reps
     if (set.isWarmUp ||
         set.weight == null ||
@@ -27,7 +27,7 @@ class Effective1RMUtils {
   }
 
   // Calculate Effective 1RM
-  static double? calculateEffective1RM(double? weight, int? reps) {
+  static double? calculateEstimated1RM(double? weight, int? reps) {
     if (weight == null || reps == null) return null;
     if (reps < 5) {
       // Brzycki Formula
@@ -36,11 +36,12 @@ class Effective1RMUtils {
       // Epley Formula
       return weight * (1 + (0.0333 * reps));
     }
+    return weight / (1.0278 - (0.0278 * reps));
   }
 
-  static String? returnEffective1RM(
+  static String? returnEstimated1RM(
       {required double weight, required int reps}) {
-    double? calculatedWeight = calculateEffective1RM(weight, reps);
+    double? calculatedWeight = calculateEstimated1RM(weight, reps);
 
     if (calculatedWeight == null) return null;
     return calculatedWeight.toStringAsFixed(2);
@@ -87,8 +88,8 @@ class Effective1RMUtils {
     int roundedReps = returnReps.round();
     int lowerReps = returnReps.round() - 1;
 
-    double calculatedEff1RM = calculateEffective1RM(weight, roundedReps)!;
-    double oneLessRepEff1RM = calculateEffective1RM(weight, lowerReps)!;
+    double calculatedEff1RM = calculateEstimated1RM(weight, roundedReps)!;
+    double oneLessRepEff1RM = calculateEstimated1RM(weight, lowerReps)!;
 
     const double epsilon = 0.01; // Tolerance for floating-point errors
 

--- a/lib/constants/utils/estimated_1RM_utils.dart
+++ b/lib/constants/utils/estimated_1RM_utils.dart
@@ -2,7 +2,7 @@
 import 'package:gym_bro/constants/enums.dart';
 
 class Estimated1RMUtils {
-  // This method determines on *The Current Set* if we want to show
+  // This method determines on The Current Set if we want to show
   // the required weight or reps to reach the Est1RM of the comparison set
   static bool showComparisonSetEstimated1RM(
       dynamic set, SetType setType, bool nullComparisonSet) {
@@ -79,10 +79,11 @@ class Estimated1RMUtils {
 
     // Calculate using both formulas
     double brzyckiReps = (1.0278 - (weight / est1RM)) / 0.0278;
-    double epleyReps = ((weight / est1RM) - 1) / 0.0333;
+    double epleyReps = ((est1RM / weight) - 1) / 0.0333;
 
     // Return the appropriate reps based on formulas
-    double returnReps = weight / est1RM > 0.8 // Brzycki works better for heavier loads
+    double returnReps = weight / est1RM >
+            0.8 //|| epleyReps < 0// Brzycki works better for heavier loads
         ? brzyckiReps
         : epleyReps;
 
@@ -97,7 +98,7 @@ class Estimated1RMUtils {
 
     // Return the reps that give the closest estimated 1RM
     return (calculatedEff1RM - est1RM).abs() <
-        (oneLessRepEff1RM - est1RM).abs() + epsilon
+            (oneLessRepEff1RM - est1RM).abs() + epsilon
         ? roundedReps.toDouble()
         : lowerReps.toDouble();
   }
@@ -106,6 +107,15 @@ class Estimated1RMUtils {
     if (weight == null || est1RM == null) return null;
 
     double calculatedReps = calculateRepsFrom1RM(weight, est1RM);
-    return calculatedReps.toStringAsFixed(0);
+
+    String repsAsIntString = calculatedReps.toStringAsFixed(0);
+
+    if (int.parse(repsAsIntString) > 30) {
+      return '30+';
+    } else if (int.parse(repsAsIntString) > 10) {
+      return '~$repsAsIntString';
+    } else {
+      return repsAsIntString;
+    }
   }
 }

--- a/lib/constants/utils/estimated_1RM_utils.dart
+++ b/lib/constants/utils/estimated_1RM_utils.dart
@@ -1,4 +1,4 @@
-// Effective 1RM class
+// Estimated 1RM class
 import 'package:gym_bro/constants/enums.dart';
 
 class Estimated1RMUtils {
@@ -16,7 +16,7 @@ class Estimated1RMUtils {
   }
 
   static bool showEstimated1RM(dynamic set) {
-    // we only want to show the Eff 1RM if we have both weight and reps
+    // we only want to show the Est 1RM if we have both weight and reps
     if (set.isWarmUp ||
         set.weight == null ||
         set.reps == null ||
@@ -26,7 +26,7 @@ class Estimated1RMUtils {
     return true;
   }
 
-  // Calculate Effective 1RM
+  // Calculate Estimated 1RM
   static double? calculateEstimated1RM(double? weight, int? reps) {
     if (weight == null || reps == null) return null;
     if (reps < 5) {
@@ -47,44 +47,43 @@ class Estimated1RMUtils {
     return calculatedWeight.toStringAsFixed(2);
   }
 
-  // Calculate Weight from Effective 1RM
-  static double calculateWeightFrom1RM(int reps, double eff1RM) {
+  // Calculate Weight from Estimated 1RM
+  static double calculateWeightFrom1RM(int reps, double est1RM) {
     if (reps < 5) {
       // Brzycki Conversion
-      return eff1RM * (1.0278 - (0.0278 * reps));
+      return est1RM * (1.0278 - (0.0278 * reps));
     } else {
       // Epley Conversion
-      return eff1RM / (1 + (0.0333 * reps));
+      return est1RM / (1 + (0.0333 * reps));
     }
   }
 
-  static String? returnCalculatedWeightFrom1RM(int? reps, double? eff1RM) {
-    if (reps == null || eff1RM == null) return null;
+  static String? returnCalculatedWeightFrom1RM(int? reps, double? est1RM) {
+    if (reps == null || est1RM == null) return null;
 
-    double calculatedWeight = calculateWeightFrom1RM(reps, eff1RM);
+    double calculatedWeight = calculateWeightFrom1RM(reps, est1RM);
 
     return calculatedWeight.toStringAsFixed(2);
   }
 
-  // Calculate Reps from Effective 1RM
+  // Calculate Reps from Estimated 1RM
   // TODO: needs validation step to decide if ±1 rep is better to display
-  // 1 rep under eff might be closer to eff than the returned rep
-  static double calculateRepsFrom1RM(double weight, double eff1RM) {
+  // 1 rep under est might be closer to est than the returned rep
+  static double calculateRepsFrom1RM(double weight, double est1RM) {
     // GPT CODE:
     // Handle invalid input
-    if (weight <= 0 || eff1RM <= 0 || weight > eff1RM) return 0;
+    if (weight <= 0 || est1RM <= 0 || weight > est1RM) return 0;
 
     // Calculate using both formulas
-    double brzyckiReps = (1.0278 - (eff1RM / weight)) / 0.0278;
-    double epleyReps = ((eff1RM / weight) - 1) / 0.0333;
+    double brzyckiReps = (1.0278 - (weight / est1RM)) / 0.0278;
+    double epleyReps = ((weight / est1RM) - 1) / 0.0333;
 
     // Return the appropriate reps based on formulas
-    double returnReps =
-    weight / eff1RM > 0.8 // Brzycki works better for heavier loads
+    double returnReps = weight / est1RM > 0.8 // Brzycki works better for heavier loads
         ? brzyckiReps
         : epleyReps;
 
-    // validating the calculated reps is closest to eff1RM
+    // validating the calculated reps is closest to est1RM
     int roundedReps = returnReps.round();
     int lowerReps = returnReps.round() - 1;
 
@@ -93,17 +92,17 @@ class Estimated1RMUtils {
 
     const double epsilon = 0.01; // Tolerance for floating-point errors
 
-    // Return the reps that give the closest effective 1RM
-    return (calculatedEff1RM - eff1RM).abs() <
-        (oneLessRepEff1RM - eff1RM).abs() + epsilon
+    // Return the reps that give the closest estimated 1RM
+    return (calculatedEff1RM - est1RM).abs() <
+        (oneLessRepEff1RM - est1RM).abs() + epsilon
         ? roundedReps.toDouble()
         : lowerReps.toDouble();
   }
 
-  static String? returnCalculatedRepsFrom1RM(double? weight, double? eff1RM) {
-    if (weight == null || eff1RM == null) return null;
+  static String? returnCalculatedRepsFrom1RM(double? weight, double? est1RM) {
+    if (weight == null || est1RM == null) return null;
 
-    double calculatedReps = calculateRepsFrom1RM(weight, eff1RM);
+    double calculatedReps = calculateRepsFrom1RM(weight, est1RM);
     return calculatedReps.toStringAsFixed(0);
   }
 }

--- a/lib/constants/utils/estimated_1RM_utils.dart
+++ b/lib/constants/utils/estimated_1RM_utils.dart
@@ -2,7 +2,9 @@
 import 'package:gym_bro/constants/enums.dart';
 
 class Estimated1RMUtils {
-  static bool showComparison1RM(
+  // This method determines on *The Current Set* if we want to show
+  // the required weight or reps to reach the Est1RM of the comparison set
+  static bool showComparisonSetEstimated1RM(
       dynamic set, SetType setType, bool nullComparisonSet) {
     if (set.isWarmUp || setType == SetType.comparison || nullComparisonSet) {
       return false;
@@ -15,6 +17,8 @@ class Estimated1RMUtils {
     return hasPartialInput;
   }
 
+  // This determines if we want to show the estimated 1RM
+  // based on the presence of the current set's weight and reps
   static bool showEstimated1RM(dynamic set) {
     // we only want to show the Est 1RM if we have both weight and reps
     if (set.isWarmUp ||
@@ -36,7 +40,6 @@ class Estimated1RMUtils {
       // Epley Formula
       return weight * (1 + (0.0333 * reps));
     }
-    return weight / (1.0278 - (0.0278 * reps));
   }
 
   static String? returnEstimated1RM(

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:gym_bro/constants/enums.dart';
-import 'package:gym_bro/constants/utils/effective_1RM_utils.dart';
+import 'package:gym_bro/constants/utils/estimated_1RM_utils.dart';
 import 'package:gym_bro/data_models/FE_data_models/exercise_set_data_models.dart';
 import 'package:gym_bro/data_models/bloc_data_models/flutter_data_models.dart';
 import 'package:gym_bro/state_management/cubits/add_exercise_cubit/add_exercise_cubit.dart';
@@ -140,9 +140,9 @@ class GeneralSetContainer extends StatelessWidget {
                 // with the cursor placed after the decimal point. To enter "11",
                 // you'd need to manually move the cursor, which can be inconvenient.
                 updateDisplay: setType == SetType.current ? false : true,
-                hintText: Effective1RMUtils.returnCalculatedWeightFrom1RM(
+                hintText: Estimated1RMUtils.returnCalculatedWeightFrom1RM(
                     set.reps,
-                    Effective1RMUtils.calculateEffective1RM(
+                    Estimated1RMUtils.calculateEstimated1RM(
                         comparisonSet?.weight, comparisonSet?.reps)),
                 updateSetFunction: (newValue) {
                   double? weightValue;
@@ -160,9 +160,9 @@ class GeneralSetContainer extends StatelessWidget {
                   child: _buildField(
                 label: "Reps",
                 value: set.reps,
-                hintText: Effective1RMUtils.returnCalculatedRepsFrom1RM(
+                hintText: Estimated1RMUtils.returnCalculatedRepsFrom1RM(
                     set.weight,
-                    Effective1RMUtils.calculateEffective1RM(
+                    Estimated1RMUtils.calculateEstimated1RM(
                         comparisonSet?.weight, comparisonSet?.reps)),
                 updateSetFunction: (newValue) {
                   int? reps;
@@ -210,24 +210,24 @@ class GeneralSetContainer extends StatelessWidget {
                         )),
               Expanded(
                   child: Container(
-                color: Effective1RMUtils.showComparison1RM(
+                color: Estimated1RMUtils.showComparison1RM(
                         set, setType, comparisonSet == null)
                     ? Colors.black.withOpacity(0.3)
-                    : Effective1RMUtils.showEffective1RM(set)
+                    : Estimated1RMUtils.showEstimated1RM(set)
                         ? Colors.yellow.withOpacity(0.3)
                         : null,
                 child: _buildField(
-                  label: "Eff. 1RM",
+                  label: "Est. 1RM",
                   // if both weight and reps are valued the effective 1RM will show,
                   // if only one is valued then we show the comparison set's Eff 1RM
                   // unless the set is warm up, in which case no 1RM is shown
-                  value: Effective1RMUtils.showComparison1RM(
+                  value: Estimated1RMUtils.showComparison1RM(
                           set, setType, comparisonSet == null)
-                      ? Effective1RMUtils.returnEffective1RM(
+                      ? Estimated1RMUtils.returnEstimated1RM(
                           weight: comparisonSet!.weight,
                           reps: comparisonSet!.reps)
-                      : Effective1RMUtils.showEffective1RM(set)
-                          ? Effective1RMUtils.returnEffective1RM(
+                      : Estimated1RMUtils.showEstimated1RM(set)
+                          ? Estimated1RMUtils.returnEstimated1RM(
                               weight: set.weight, reps: set.reps)
                           : "",
                   setType: setType,

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
@@ -275,9 +275,14 @@ class GeneralSetContainer extends StatelessWidget {
                 label: "+ Reps",
                 value: set.extraReps,
                 updateSetFunction: (newValue) {
-                  int extraReps = int.parse(newValue);
+                  int? extraReps;
+                  if (newValue == "") {
+                    extraReps = null;
+                  } else {
+                    extraReps = int.parse(newValue);
+                  }
                   BlocProvider.of<AddExerciseCubit>(context)
-                      .updateCurrentSet(CurrentSet(extraReps: extraReps));
+                      .updateExtraRepsCurrentSet(extraReps);
                 },
                 setType: setType,
               )),

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
@@ -20,26 +20,6 @@ enum TextFieldType { duration, text, number, bool }
 
 // Effective 1RM class
 class Effective1RMUtils {
-  static _(dynamic set, GeneralExerciseSetModel? comparisonSet) {
-    if (set.isWarmUp || set.weight == null && set.reps == null) {
-      // don't show
-    }
-    if (set.weight == null || set.reps == null) {
-      if (comparisonSet == null) {
-        // don't show
-      }
-      comparisonSet as GeneralExerciseSetModel;
-      // show comparison set 1RM
-      // Highlight in black
-      if (set.weight == null) {
-        double effectiveWeight = calculateWeightFrom1RM(set.reps,
-            calculateEffective1RM(comparisonSet.weight, comparisonSet.reps));
-      } else {
-        int effectiveReps = calculateRepsFrom1RM(set.weight,
-            calculateEffective1RM(comparisonSet.weight, comparisonSet.reps));
-      }
-    }
-  }
 
   static bool showComparison1RM(
       dynamic set, SetType setType, bool nullComparisonSet) {

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
@@ -239,9 +239,14 @@ class GeneralSetContainer extends StatelessWidget {
                     Effective1RMUtils.calculateEffective1RM(
                         comparisonSet?.weight, comparisonSet?.reps)),
                 updateSetFunction: (newValue) {
-                  double weightValue = double.parse(newValue);
+                  double? weightValue;
+                  if (newValue == "") {
+                    weightValue = null;
+                  } else {
+                    weightValue = double.parse(newValue);
+                  }
                   BlocProvider.of<AddExerciseCubit>(context)
-                      .updateCurrentSet(CurrentSet(weight: weightValue));
+                      .updateWeightCurrentSet(weightValue);
                 },
                 setType: setType,
               )),
@@ -254,9 +259,14 @@ class GeneralSetContainer extends StatelessWidget {
                     Effective1RMUtils.calculateEffective1RM(
                         comparisonSet?.weight, comparisonSet?.reps)),
                 updateSetFunction: (newValue) {
-                  int reps = int.parse(newValue);
+                  int? reps;
+                  if (newValue == "") {
+                    reps = null;
+                  } else {
+                    reps = int.parse(newValue);
+                  }
                   BlocProvider.of<AddExerciseCubit>(context)
-                      .updateCurrentSet(CurrentSet(reps: reps));
+                      .updateRepsCurrentSet(reps);
                 },
                 setType: setType,
               )),

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
@@ -20,7 +20,6 @@ enum TextFieldType { duration, text, number, bool }
 
 // Effective 1RM class
 class Effective1RMUtils {
-
   static bool showComparison1RM(
       dynamic set, SetType setType, bool nullComparisonSet) {
     if (set.isWarmUp || setType == SetType.comparison || nullComparisonSet) {
@@ -45,7 +44,9 @@ class Effective1RMUtils {
     return true;
   }
 
-  static double calculateEffective1RM(double weight, int reps) {
+  // Calculate Effective 1RM
+  static double? calculateEffective1RM(double? weight, int? reps) {
+    if (weight == null || reps == null) return null;
     if (reps < 5) {
       // Brzycki Formula
       return weight / (1.0278 - (0.0278 * reps));
@@ -55,12 +56,15 @@ class Effective1RMUtils {
     }
   }
 
-  static String returnEffective1RM(
+  static String? returnEffective1RM(
       {required double weight, required int reps}) {
-    double calculatedWeight = calculateEffective1RM(weight, reps);
+    double? calculatedWeight = calculateEffective1RM(weight, reps);
+
+    if (calculatedWeight == null) return null;
     return calculatedWeight.toStringAsFixed(2);
   }
 
+  // Calculate Weight from Effective 1RM
   static double calculateWeightFrom1RM(int reps, double eff1RM) {
     if (reps < 5) {
       // Brzycki Conversion
@@ -71,7 +75,16 @@ class Effective1RMUtils {
     }
   }
 
-  static int calculateRepsFrom1RM(double weight, double eff1RM) {
+  static String? returnCalculatedWeightFrom1RM(int? reps, double? eff1RM) {
+    if (reps == null || eff1RM == null) return null;
+
+    double calculatedWeight = calculateWeightFrom1RM(reps, eff1RM);
+
+    return calculatedWeight.toStringAsFixed(2);
+  }
+
+  // Calculate Reps from Effective 1RM
+  static double calculateRepsFrom1RM(double weight, double eff1RM) {
     double conversionMethod(bool isEpley) {
       double c1 = isEpley ? 1 : 1.0278;
       double c2 = isEpley ? 0.0333 : 0.0278;
@@ -85,7 +98,14 @@ class Effective1RMUtils {
         ? conversionMethod(false)
         : conversionMethod(true);
 
-    return answer.floor();
+    return answer;
+  }
+
+  static String? returnCalculatedRepsFrom1RM(double? weight, double? eff1RM) {
+    if (weight == null || eff1RM == null) return null;
+
+    double calculatedReps = calculateRepsFrom1RM(weight, eff1RM);
+    return calculatedReps.toStringAsFixed(0);
   }
 }
 
@@ -214,6 +234,10 @@ class GeneralSetContainer extends StatelessWidget {
                 // with the cursor placed after the decimal point. To enter "11",
                 // you'd need to manually move the cursor, which can be inconvenient.
                 updateDisplay: setType == SetType.current ? false : true,
+                hintText: Effective1RMUtils.returnCalculatedWeightFrom1RM(
+                    set.reps,
+                    Effective1RMUtils.calculateEffective1RM(
+                        comparisonSet?.weight, comparisonSet?.reps)),
                 updateSetFunction: (newValue) {
                   double weightValue = double.parse(newValue);
                   BlocProvider.of<AddExerciseCubit>(context)
@@ -225,6 +249,10 @@ class GeneralSetContainer extends StatelessWidget {
                   child: _buildField(
                 label: "Reps",
                 value: set.reps,
+                hintText: Effective1RMUtils.returnCalculatedRepsFrom1RM(
+                    set.weight,
+                    Effective1RMUtils.calculateEffective1RM(
+                        comparisonSet?.weight, comparisonSet?.reps)),
                 updateSetFunction: (newValue) {
                   int reps = int.parse(newValue);
                   BlocProvider.of<AddExerciseCubit>(context)
@@ -307,6 +335,7 @@ class GeneralSetContainer extends StatelessWidget {
       required dynamic value,
       required SetType setType,
       bool updateDisplay = true,
+      String? hintText,
       Function(dynamic)? updateSetFunction}) {
     Map<String, TextFieldType> textFieldTypeMap = {
       // "Warm up Set": TextFieldType.text,
@@ -336,6 +365,7 @@ class GeneralSetContainer extends StatelessWidget {
           GeneralSetField(
             value: value,
             setType: setType,
+            hintText: hintText,
             updateField: updateDisplay,
             autoFocus: label == "Weight" && value == null ? true : false,
             inputType: textFieldTypeMap[label] == TextFieldType.number

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
@@ -90,6 +90,21 @@ class GeneralSetContainer extends StatelessWidget {
 
   double get notesContainerHeight => 28;
 
+  double _calculateEffective1RM(double weight, int reps) {
+    if (reps < 5) {
+      // Brzycki Formula
+      return weight / (1.0278 - (0.0278 * reps));
+    } else {
+      // Epley Formula
+      return weight * (1 + (0.0333 * reps));
+    }
+  }
+
+  String returnEffective1RM({required double weight, required int reps}) {
+    double calculatedWeight = _calculateEffective1RM(weight, reps);
+    return calculatedWeight.toStringAsFixed(2);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -105,7 +120,9 @@ class GeneralSetContainer extends StatelessWidget {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: [
-                  WorkingSetCount(setNumber: setNumber, isCurrent: setType == SetType.current),
+                  WorkingSetCount(
+                      setNumber: setNumber,
+                      isCurrent: setType == SetType.current),
                   const Spacer(),
                   if (setType == SetType.current)
                     FinishSetButton(currentSet: currentSet),
@@ -186,13 +203,19 @@ class GeneralSetContainer extends StatelessWidget {
                           value: set.setDuration ?? "- - -",
                           setType: setType,
                         )),
-              if (false)
-                Expanded(
-                    child: _buildField(
-                  label: "Effort",
-                  value: null,
+              Expanded(
+                  child: Container(
+                color: !(set.weight == null || set.reps == null || set.weight == 0 || set.isWarmUp)
+                    ? Colors.yellow.withOpacity(0.3)
+                    : null,
+                child: _buildField(
+                  label: "Eff. 1RM",
+                  value: !(set.weight == null || set.reps == null || set.weight == 0 || set.isWarmUp)
+                      ? returnEffective1RM(weight: set.weight, reps: set.reps)
+                      : "",
                   setType: setType,
-                )),
+                ),
+              )),
             ],
           ),
           if (setType == SetType.current || set.notes != null)
@@ -226,7 +249,7 @@ class GeneralSetContainer extends StatelessWidget {
       "Reps": TextFieldType.number,
       "+ Reps": TextFieldType.number,
       "Duration": TextFieldType.duration,
-      "Effort": TextFieldType.text,
+      "Eff. 1RM": TextFieldType.text,
       "Notes": TextFieldType.text,
     };
 

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
@@ -210,7 +210,7 @@ class GeneralSetContainer extends StatelessWidget {
                         )),
               Expanded(
                   child: Container(
-                color: Estimated1RMUtils.showComparison1RM(
+                color: Estimated1RMUtils.showComparisonSetEstimated1RM(
                         set, setType, comparisonSet == null)
                     ? Colors.black.withOpacity(0.3)
                     : Estimated1RMUtils.showEstimated1RM(set)
@@ -221,7 +221,7 @@ class GeneralSetContainer extends StatelessWidget {
                   // if both weight and reps are valued the effective 1RM will show,
                   // if only one is valued then we show the comparison set's Eff 1RM
                   // unless the set is warm up, in which case no 1RM is shown
-                  value: Estimated1RMUtils.showComparison1RM(
+                  value: Estimated1RMUtils.showComparisonSetEstimated1RM(
                           set, setType, comparisonSet == null)
                       ? Estimated1RMUtils.returnEstimated1RM(
                           weight: comparisonSet!.weight,

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:gym_bro/constants/enums.dart';
+import 'package:gym_bro/constants/utils/effective_1RM_utils.dart';
 import 'package:gym_bro/data_models/FE_data_models/exercise_set_data_models.dart';
 import 'package:gym_bro/data_models/bloc_data_models/flutter_data_models.dart';
 import 'package:gym_bro/state_management/cubits/add_exercise_cubit/add_exercise_cubit.dart';
@@ -12,102 +14,6 @@ import 'set_field_types/notes_text_field_animated_container_widget.dart';
 import 'set_field_types/general_set_field_widget.dart';
 import 'set_field_types/warm_up_check_box.dart';
 import 'working_warmup_set_header_counter_widget.dart';
-
-// enums
-enum SetType { comparison, current, completed }
-
-enum TextFieldType { duration, text, number, bool }
-
-// Effective 1RM class
-class Effective1RMUtils {
-  static bool showComparison1RM(
-      dynamic set, SetType setType, bool nullComparisonSet) {
-    if (set.isWarmUp || setType == SetType.comparison || nullComparisonSet) {
-      return false;
-    }
-
-    // Check for partial inputs
-    bool hasPartialInput = (set.weight == null && set.reps != null) ||
-        (set.weight != null && set.reps == null);
-
-    return hasPartialInput;
-  }
-
-  static bool showEffective1RM(dynamic set) {
-    // we only want to show the Eff 1RM if we have both weight and reps
-    if (set.isWarmUp ||
-        set.weight == null ||
-        set.reps == null ||
-        set.weight == 0) {
-      return false;
-    }
-    return true;
-  }
-
-  // Calculate Effective 1RM
-  static double? calculateEffective1RM(double? weight, int? reps) {
-    if (weight == null || reps == null) return null;
-    if (reps < 5) {
-      // Brzycki Formula
-      return weight / (1.0278 - (0.0278 * reps));
-    } else {
-      // Epley Formula
-      return weight * (1 + (0.0333 * reps));
-    }
-  }
-
-  static String? returnEffective1RM(
-      {required double weight, required int reps}) {
-    double? calculatedWeight = calculateEffective1RM(weight, reps);
-
-    if (calculatedWeight == null) return null;
-    return calculatedWeight.toStringAsFixed(2);
-  }
-
-  // Calculate Weight from Effective 1RM
-  static double calculateWeightFrom1RM(int reps, double eff1RM) {
-    if (reps < 5) {
-      // Brzycki Conversion
-      return eff1RM / (1.0278 - (0.0278 * reps));
-    } else {
-      // Epley Conversion
-      return eff1RM * (1 + (0.0333 * reps));
-    }
-  }
-
-  static String? returnCalculatedWeightFrom1RM(int? reps, double? eff1RM) {
-    if (reps == null || eff1RM == null) return null;
-
-    double calculatedWeight = calculateWeightFrom1RM(reps, eff1RM);
-
-    return calculatedWeight.toStringAsFixed(2);
-  }
-
-  // Calculate Reps from Effective 1RM
-  static double calculateRepsFrom1RM(double weight, double eff1RM) {
-    double conversionMethod({required bool isEpley}) {
-      double c1 = isEpley ? 1 : 1.0278;
-      double c2 = isEpley ? 0.0333 : 0.0278;
-
-      double numerator = c1 - (weight / eff1RM);
-
-      return numerator / c2;
-    }
-
-    double answer = conversionMethod(isEpley: true) < 5
-        ? conversionMethod(isEpley: false)
-        : conversionMethod(isEpley: true);
-
-    return answer;
-  }
-
-  static String? returnCalculatedRepsFrom1RM(double? weight, double? eff1RM) {
-    if (weight == null || eff1RM == null) return null;
-
-    double calculatedReps = calculateRepsFrom1RM(weight, eff1RM);
-    return calculatedReps.toStringAsFixed(0);
-  }
-}
 
 Map<String, TextFieldType> textFieldTypeMap = {
   "Rest Time": TextFieldType.duration,

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
@@ -85,7 +85,7 @@ class Effective1RMUtils {
 
   // Calculate Reps from Effective 1RM
   static double calculateRepsFrom1RM(double weight, double eff1RM) {
-    double conversionMethod(bool isEpley) {
+    double conversionMethod({required bool isEpley}) {
       double c1 = isEpley ? 1 : 1.0278;
       double c2 = isEpley ? 0.0333 : 0.0278;
 
@@ -94,9 +94,9 @@ class Effective1RMUtils {
       return numerator / c2;
     }
 
-    double answer = conversionMethod(true) < 5
-        ? conversionMethod(false)
-        : conversionMethod(true);
+    double answer = conversionMethod(isEpley: true) < 5
+        ? conversionMethod(isEpley: false)
+        : conversionMethod(isEpley: true);
 
     return answer;
   }

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart
@@ -15,17 +15,6 @@ import 'set_field_types/general_set_field_widget.dart';
 import 'set_field_types/warm_up_check_box.dart';
 import 'working_warmup_set_header_counter_widget.dart';
 
-Map<String, TextFieldType> textFieldTypeMap = {
-  "Rest Time": TextFieldType.duration,
-  "Warm Up": TextFieldType.number,
-  "Weight": TextFieldType.number,
-  "Reps": TextFieldType.number,
-  "+ Reps": TextFieldType.number,
-  "Duration": TextFieldType.duration,
-  "Effort": TextFieldType.text,
-  "Notes": TextFieldType.text,
-};
-
 class GeneralSetContainer extends StatelessWidget {
   final GeneralExerciseSetModel? comparisonSet;
   final CurrentSet? currentSet;
@@ -218,9 +207,6 @@ class GeneralSetContainer extends StatelessWidget {
                         : null,
                 child: _buildField(
                   label: "Est. 1RM",
-                  // if both weight and reps are valued the effective 1RM will show,
-                  // if only one is valued then we show the comparison set's Eff 1RM
-                  // unless the set is warm up, in which case no 1RM is shown
                   value: Estimated1RMUtils.showComparisonSetEstimated1RM(
                           set, setType, comparisonSet == null)
                       ? Estimated1RMUtils.returnEstimated1RM(
@@ -259,15 +245,13 @@ class GeneralSetContainer extends StatelessWidget {
       String? hintText,
       Function(dynamic)? updateSetFunction}) {
     Map<String, TextFieldType> textFieldTypeMap = {
-      // "Warm up Set": TextFieldType.text,
-      // "Working Set": TextFieldType.text,
       "Rest Time": TextFieldType.duration,
       "Warm Up": TextFieldType.bool,
       "Weight": TextFieldType.number,
       "Reps": TextFieldType.number,
       "+ Reps": TextFieldType.number,
       "Duration": TextFieldType.duration,
-      "Eff. 1RM": TextFieldType.text,
+      "Est. 1RM": TextFieldType.text,
       "Notes": TextFieldType.text,
     };
 

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/set_field_types/duration_text_field_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/set_field_types/duration_text_field_widget.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-
-import '../general_set_container_widget.dart';
+import 'package:gym_bro/constants/enums.dart';
 
 class DurationTextFieldWidget extends StatelessWidget {
   final String? displayDuration;

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/set_field_types/general_set_field_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/set_field_types/general_set_field_widget.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:gym_bro/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart';
+import 'package:gym_bro/constants/enums.dart';
 
 class GeneralSetField extends StatefulWidget {
   final dynamic value;

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/set_field_types/general_set_field_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/set_field_types/general_set_field_widget.dart
@@ -8,6 +8,7 @@ class GeneralSetField extends StatefulWidget {
   final SetType setType;
   final TextInputType inputType;
   final bool autoFocus;
+  final String? hintText;
 
   const GeneralSetField(
       {super.key,
@@ -15,6 +16,7 @@ class GeneralSetField extends StatefulWidget {
       this.updateSetFunction,
       required this.setType,
       required this.inputType,
+        this.hintText,
       this.autoFocus = false,
       this.updateField = true});
 
@@ -63,7 +65,8 @@ class _GeneralSetFieldState extends State<GeneralSetField> {
       style: TextStyle(color: widget.activeColour),
       cursorColor: widget.activeColour,
       autofocus: widget.autoFocus,
-      decoration: const InputDecoration(
+      decoration: InputDecoration(
+        hintText: widget.hintText,
           border: InputBorder.none,
           contentPadding: EdgeInsets.only(bottom: 5) //, top: 5),
           ),

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/set_field_types/notes_text_field_animated_container_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/set_field_types/notes_text_field_animated_container_widget.dart
@@ -64,35 +64,35 @@ class _ExpandableNotesTextFieldState extends State<ExpandableNotesTextField> {
               children: [
                 const Spacer(),
                 Padding(
-                    padding: const EdgeInsets.only(top: 5),
-                    child: SizedBox(
-                      width: 35,
-                      child: Text(
-                        "Notes..",
-                        style: TextStyle(
-                            color: _isExpanded
-                                ? widget.headerTextStyle.color
-                                : widget.headerTextStyle.color!
-                                    .withOpacity(opacityValue),
-                            fontSize: 10),
-                      ),
+                  padding: const EdgeInsets.only(top: 5),
+                  child: SizedBox(
+                    width: 35,
+                    child: Text(
+                      "Notes..",
+                      style: TextStyle(
+                          color: _isExpanded
+                              ? widget.headerTextStyle.color
+                              : widget.headerTextStyle.color!
+                                  .withOpacity(opacityValue),
+                          fontSize: 10),
                     ),
                   ),
+                ),
                 const Spacer(flex: 12),
                 SizedBox(
-                    width: 35,
-                    child: Icon(
-                      _isExpanded ? Icons.arrow_drop_down : Icons.arrow_right,
-                      color: widget.setType == SetType.completed
-                          ? _isExpanded
-                              ? Colors.black
-                              : Colors.black.withOpacity(opacityValue)
-                          : _isExpanded
-                              ? Colors.white
-                              : Colors.white.withOpacity(opacityValue),
-                      size: 24,
-                    ),
+                  width: 35,
+                  child: Icon(
+                    _isExpanded ? Icons.arrow_drop_down : Icons.arrow_right,
+                    color: widget.setType == SetType.completed
+                        ? _isExpanded
+                            ? Colors.black
+                            : Colors.black.withOpacity(opacityValue)
+                        : _isExpanded
+                            ? Colors.white
+                            : Colors.white.withOpacity(opacityValue),
+                    size: 24,
                   ),
+                ),
                 const Spacer()
               ],
             ),
@@ -111,9 +111,15 @@ class _ExpandableNotesTextFieldState extends State<ExpandableNotesTextField> {
                     autoFocus: true,
                     setType: widget.setType,
                     inputType: TextInputType.text,
-                    updateSetFunction: (notes) {
+                    updateSetFunction: (newValue) {
+                      String? notes;
+                      if (newValue == "") {
+                        notes = null;
+                      } else {
+                        notes = newValue;
+                      }
                       BlocProvider.of<AddExerciseCubit>(context)
-                          .updateCurrentSet(CurrentSet(notes: notes));
+                          .updateNotesCurrentSet(notes);
                     },
                   ),
                 )

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/set_field_types/notes_text_field_animated_container_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/set_field_types/notes_text_field_animated_container_widget.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gym_bro/data_models/bloc_data_models/flutter_data_models.dart';
 import 'package:gym_bro/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart';
 import 'package:gym_bro/state_management/cubits/add_exercise_cubit/add_exercise_cubit.dart';
 

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/set_field_types/notes_text_field_animated_container_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/set_field_types/notes_text_field_animated_container_widget.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:gym_bro/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/general_set_container_widget.dart';
+import 'package:gym_bro/constants/enums.dart';
 import 'package:gym_bro/state_management/cubits/add_exercise_cubit/add_exercise_cubit.dart';
 
 import 'general_set_field_widget.dart';

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/set_field_types/warm_up_check_box.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_cards/set_field_types/warm_up_check_box.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-
-import '../general_set_container_widget.dart';
+import 'package:gym_bro/constants/enums.dart';
 
 class WarmupCheckbox extends StatefulWidget {
   final bool isBoxChecked;

--- a/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_list_widget.dart
+++ b/lib/design/widgets/workout_page_widgets/add_exercise_modal/sets_list/sets_list_widget.dart
@@ -100,9 +100,11 @@ class SetsListContainer extends StatelessWidget {
                             date: comparisonExerciseDate,
                             workingSetsCount:
                                 comparisonExerciseTotalWorkingSets),
+                        // This is the black comparison set container
                         GeneralSetContainer(
                             comparisonSet: comparisonSet,
                             setNumber: comparisonExerciseWorkingSetNumber),
+                        // This is the current set container
                         buildGeneralSetContainer(
                           comparisonSet: comparisonSet,
                         ),
@@ -111,7 +113,8 @@ class SetsListContainer extends StatelessWidget {
                   },
                 );
               }
-              // If theres no previous exercise data for this movement:
+              // If theres no previous exercise data for this movement
+              // just show the current set container
               return currentSet != null
                   ? buildGeneralSetContainer()
                   : Container();

--- a/lib/state_management/cubits/add_exercise_cubit/add_exercise_cubit.dart
+++ b/lib/state_management/cubits/add_exercise_cubit/add_exercise_cubit.dart
@@ -74,28 +74,84 @@ class AddExerciseCubit extends Cubit<AddExerciseState> {
   }
 
   updateCurrentSet(CurrentSet set) {
-    AddExerciseState generatedState = state.copyWith();
+    AddExerciseState currentState = state.copyWith();
 
-    CurrentSet updatedState = set;
+    CurrentSet updatedSet;
     // TODO: need to work out what this is about
-    if (generatedState.currentSet != null) {
-      updatedState = CurrentSet(
-        isWarmUp: set.isWarmUp ?? generatedState.currentSet!.isWarmUp,
-        weight: set.weight ?? generatedState.currentSet!.weight,
-        reps: set.reps ?? generatedState.currentSet!.reps,
-        extraReps: set.extraReps ?? generatedState.currentSet!.extraReps,
-        setDuration: set.setDuration ?? generatedState.currentSet!.setDuration,
-        notes: set.notes ?? generatedState.currentSet!.notes,
+    // this is causing a problem because if we want to remove a value its passed through as null
+    // the block below then sees that the value is null and assigns it to the previous value..
+    if (currentState.currentSet != null) {
+      updatedSet = CurrentSet(
+        isWarmUp: set.isWarmUp ?? currentState.currentSet!.isWarmUp,
+        weight: set.weight ?? currentState.currentSet!.weight,
+        reps: set.reps ?? currentState.currentSet!.reps,
+        extraReps: set.extraReps ?? currentState.currentSet!.extraReps,
+        setDuration: set.setDuration ?? currentState.currentSet!.setDuration,
+        notes: set.notes ?? currentState.currentSet!.notes,
       );
+    } else {
+      updatedSet = const CurrentSet();
     }
 
     emit(AddExerciseState(
-        selectedMovement: generatedState.selectedMovement,
-        selectedMovementId: generatedState.selectedMovementId,
-        currentSet: updatedState,
-        setsDone: generatedState.setsDone,
-        numWorkingSets: generatedState.numWorkingSets,
-        workedMuscleGroups: generatedState.workedMuscleGroups));
+        selectedMovement: currentState.selectedMovement,
+        selectedMovementId: currentState.selectedMovementId,
+        currentSet: updatedSet,
+        setsDone: currentState.setsDone,
+        numWorkingSets: currentState.numWorkingSets,
+        workedMuscleGroups: currentState.workedMuscleGroups));
+  }
+
+  updateWeightCurrentSet(double? weight) {
+    AddExerciseState currentState = state.copyWith();
+
+    CurrentSet updatedSet;
+    if (currentState.currentSet != null) {
+      updatedSet = CurrentSet(
+        isWarmUp: currentState.currentSet!.isWarmUp,
+        weight: weight,
+        reps: currentState.currentSet!.reps,
+        extraReps: currentState.currentSet!.extraReps,
+        setDuration: currentState.currentSet!.setDuration,
+        notes: currentState.currentSet!.notes,
+      );
+    } else {
+      updatedSet = const CurrentSet();
+    }
+
+    emit(AddExerciseState(
+        selectedMovement: currentState.selectedMovement,
+        selectedMovementId: currentState.selectedMovementId,
+        currentSet: updatedSet,
+        setsDone: currentState.setsDone,
+        numWorkingSets: currentState.numWorkingSets,
+        workedMuscleGroups: currentState.workedMuscleGroups));
+  }
+
+  updateRepsCurrentSet(int? reps) {
+    AddExerciseState currentState = state.copyWith();
+
+    CurrentSet updatedSet;
+    if (currentState.currentSet != null) {
+      updatedSet = CurrentSet(
+        isWarmUp: currentState.currentSet!.isWarmUp,
+        weight: currentState.currentSet!.weight,
+        reps: reps,
+        extraReps: currentState.currentSet!.extraReps,
+        setDuration: currentState.currentSet!.setDuration,
+        notes: currentState.currentSet!.notes,
+      );
+    } else {
+      updatedSet = const CurrentSet();
+    }
+
+    emit(AddExerciseState(
+        selectedMovement: currentState.selectedMovement,
+        selectedMovementId: currentState.selectedMovementId,
+        currentSet: updatedSet,
+        setsDone: currentState.setsDone,
+        numWorkingSets: currentState.numWorkingSets,
+        workedMuscleGroups: currentState.workedMuscleGroups));
   }
 
   void saveCompletedSet() {

--- a/lib/state_management/cubits/add_exercise_cubit/add_exercise_cubit.dart
+++ b/lib/state_management/cubits/add_exercise_cubit/add_exercise_cubit.dart
@@ -73,13 +73,34 @@ class AddExerciseCubit extends Cubit<AddExerciseState> {
     emit(generatedState);
   }
 
+  // Updating State CurrentSet
+  // ============================
+  // as theres no way to differentiate between null values explicitly set
+  // and null values due to omitted field assignment:
+  //    exSet = CurrentSet(reps: null);
+  //    exSet.reps == null && exSet.weight == null
+  // there's no good way of updating a field to null with a generalised method
+  // the update set method has been split for each field
+  // that could be meaningfully set to null
+  void _emitUpdatedCurrentSetState(CurrentSet updatedSet) {
+    AddExerciseState currentState = state.copyWith();
+
+    emit(AddExerciseState(
+      selectedMovement: currentState.selectedMovement,
+      selectedMovementId: currentState.selectedMovementId,
+      currentSet: updatedSet,
+      setsDone: currentState.setsDone,
+      numWorkingSets: currentState.numWorkingSets,
+      workedMuscleGroups: currentState.workedMuscleGroups,
+    ));
+  }
+
+  // Generalised method for fields that can't be meaningfully re-set to null on update
+  // isWarmUp, setDuration
   updateCurrentSet(CurrentSet set) {
     AddExerciseState currentState = state.copyWith();
 
     CurrentSet updatedSet;
-    // TODO: need to work out what this is about
-    // this is causing a problem because if we want to remove a value its passed through as null
-    // the block below then sees that the value is null and assigns it to the previous value..
     if (currentState.currentSet != null) {
       updatedSet = CurrentSet(
         isWarmUp: set.isWarmUp ?? currentState.currentSet!.isWarmUp,
@@ -93,13 +114,7 @@ class AddExerciseCubit extends Cubit<AddExerciseState> {
       updatedSet = const CurrentSet();
     }
 
-    emit(AddExerciseState(
-        selectedMovement: currentState.selectedMovement,
-        selectedMovementId: currentState.selectedMovementId,
-        currentSet: updatedSet,
-        setsDone: currentState.setsDone,
-        numWorkingSets: currentState.numWorkingSets,
-        workedMuscleGroups: currentState.workedMuscleGroups));
+    _emitUpdatedCurrentSetState(updatedSet);
   }
 
   updateWeightCurrentSet(double? weight) {
@@ -119,13 +134,7 @@ class AddExerciseCubit extends Cubit<AddExerciseState> {
       updatedSet = const CurrentSet();
     }
 
-    emit(AddExerciseState(
-        selectedMovement: currentState.selectedMovement,
-        selectedMovementId: currentState.selectedMovementId,
-        currentSet: updatedSet,
-        setsDone: currentState.setsDone,
-        numWorkingSets: currentState.numWorkingSets,
-        workedMuscleGroups: currentState.workedMuscleGroups));
+    _emitUpdatedCurrentSetState(updatedSet);
   }
 
   updateRepsCurrentSet(int? reps) {
@@ -145,14 +154,50 @@ class AddExerciseCubit extends Cubit<AddExerciseState> {
       updatedSet = const CurrentSet();
     }
 
-    emit(AddExerciseState(
-        selectedMovement: currentState.selectedMovement,
-        selectedMovementId: currentState.selectedMovementId,
-        currentSet: updatedSet,
-        setsDone: currentState.setsDone,
-        numWorkingSets: currentState.numWorkingSets,
-        workedMuscleGroups: currentState.workedMuscleGroups));
+    _emitUpdatedCurrentSetState(updatedSet);
   }
+
+  updateExtraRepsCurrentSet(int? extraReps) {
+    AddExerciseState currentState = state.copyWith();
+
+    CurrentSet updatedSet;
+    if (currentState.currentSet != null) {
+      updatedSet = CurrentSet(
+        isWarmUp: currentState.currentSet!.isWarmUp,
+        weight: currentState.currentSet!.weight,
+        reps: currentState.currentSet!.reps,
+        extraReps: extraReps,
+        setDuration: currentState.currentSet!.setDuration,
+        notes: currentState.currentSet!.notes,
+      );
+    } else {
+      updatedSet = const CurrentSet();
+    }
+
+    _emitUpdatedCurrentSetState(updatedSet);
+  }
+
+  updateNotesCurrentSet(String? notes) {
+    AddExerciseState currentState = state.copyWith();
+
+    CurrentSet updatedSet;
+    if (currentState.currentSet != null) {
+      updatedSet = CurrentSet(
+        isWarmUp: currentState.currentSet!.isWarmUp,
+        weight: currentState.currentSet!.weight,
+        reps: currentState.currentSet!.reps,
+        extraReps: currentState.currentSet!.extraReps,
+        setDuration: currentState.currentSet!.setDuration,
+        notes: notes,
+      );
+    } else {
+      updatedSet = const CurrentSet();
+    }
+
+    _emitUpdatedCurrentSetState(updatedSet);
+  }
+
+  // ==============================
 
   void saveCompletedSet() {
     AddExerciseState generatedState = state.copyWith();

--- a/lib/state_management/cubits/add_exercise_cubit/add_exercise_cubit.dart
+++ b/lib/state_management/cubits/add_exercise_cubit/add_exercise_cubit.dart
@@ -50,8 +50,6 @@ class AddExerciseCubit extends Cubit<AddExerciseState> {
   }
 
   selectExercise(MovementMuscleGroupJoin movementMuscleGroupJoin) {
-    AddExerciseState generatedState = state.copyWith();
-
     emit(AddExerciseState(
         selectedMovement: movementMuscleGroupJoin.movementName,
         selectedMovementId: movementMuscleGroupJoin.movementId,

--- a/test/constants/utils/estimated_1RM_utils_test.dart
+++ b/test/constants/utils/estimated_1RM_utils_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gym_bro/constants/enums.dart';
+import 'package:gym_bro/constants/utils/estimated_1RM_utils.dart';
+
+// TODO: add more tests, cba agr
+
+class MockSet {
+  final bool isWarmUp;
+  final double? weight;
+  final int? reps;
+
+  MockSet({required this.isWarmUp, this.weight, this.reps});
+}
+
+void main() {
+  group('showComparisonSetEstimated1RM', () {
+    test('returns false for warm-up set', () {
+      final set = MockSet(isWarmUp: true, weight: 100, reps: 5);
+
+      expect(
+          Estimated1RMUtils.showComparisonSetEstimated1RM(
+              set, SetType.current, false),
+          false);
+    });
+
+    test('returns false for comparison set type', () {
+      final set = MockSet(isWarmUp: false, weight: 100, reps: 5);
+      expect(
+          Estimated1RMUtils.showComparisonSetEstimated1RM(
+              set, SetType.comparison, false),
+          false);
+    });
+
+    test('returns false when nullComparisonSet is true', () {
+      final set = MockSet(isWarmUp: false, weight: 100, reps: 5);
+      expect(
+          Estimated1RMUtils.showComparisonSetEstimated1RM(
+              set, SetType.current, true),
+          false);
+    });
+
+    test('returns false when weight and reps are both provided', () {
+      final set = MockSet(isWarmUp: false, weight: 100, reps: 5);
+      expect(
+          Estimated1RMUtils.showComparisonSetEstimated1RM(
+              set, SetType.current, false),
+          false);
+    });
+
+    test('returns true when only reps are provided', () {
+      final set = MockSet(isWarmUp: false, weight: null, reps: 5);
+      expect(
+          Estimated1RMUtils.showComparisonSetEstimated1RM(
+              set, SetType.current, false),
+          true);
+    });
+
+    test('returns true when only weight is provided', () {
+      final set = MockSet(isWarmUp: false, weight: 100, reps: null);
+      expect(
+          Estimated1RMUtils.showComparisonSetEstimated1RM(
+              set, SetType.current, false),
+          true);
+    });
+  });
+  group('showEstimated1RM', () {
+    test('returns false for warm-up set', () {
+      final set = MockSet(isWarmUp: true, weight: 100, reps: 5);
+      expect(Estimated1RMUtils.showEstimated1RM(set), false);
+    });
+
+    test('returns false when weight is null', () {
+      final set = MockSet(isWarmUp: false, weight: null, reps: 5);
+      expect(Estimated1RMUtils.showEstimated1RM(set), false);
+    });
+
+    test('returns false when reps are null', () {
+      final set = MockSet(isWarmUp: false, weight: 100, reps: null);
+      expect(Estimated1RMUtils.showEstimated1RM(set), false);
+    });
+
+    test('returns false when weight is 0', () {
+      final set = MockSet(isWarmUp: false, weight: 0, reps: 5);
+      expect(Estimated1RMUtils.showEstimated1RM(set), false);
+    });
+
+    test(
+        'returns true when both weight and reps are provided and weight is nonzero',
+        () {
+      final set = MockSet(isWarmUp: false, weight: 100, reps: 5);
+      expect(Estimated1RMUtils.showEstimated1RM(set), true);
+    });
+  });
+
+  // Calc 1RM
+  group('calculateEstimated1RM', () {
+    test('testing a effective 1RM for reps < 5', () {
+      var testWeightAndRepRanges = [
+        {'weight': 100, 'reps': 1, 'expected': 100},
+        {'weight': 50, 'reps': 1, 'expected': 50},
+        {'weight': 33, 'reps': 1, 'expected': 33},
+        {'weight': 1.5, 'reps': 1, 'expected': 1.5},
+        {'weight': 100, 'reps': 2, 'expected': 102.9},
+        {'weight': 100, 'reps': 3, 'expected': 105.9},
+        {'weight': 100, 'reps': 4, 'expected': 109.1},
+        {'weight': 55, 'reps': 2, 'expected': 56.6},
+        {'weight': 55, 'reps': 3, 'expected': 58.2},
+        {'weight': 55, 'reps': 4, 'expected': 60},
+      ];
+
+      for (var test in testWeightAndRepRanges) {
+        double result = Estimated1RMUtils.calculateEstimated1RM(
+            test['weight']!.toDouble(), test['reps']!.toInt())!;
+        double roundedResult = double.parse(result.toStringAsFixed(1));
+
+        expect(roundedResult, test['expected']!.toDouble());
+      }
+    });
+    // This test is tricky to do as we use a different formula
+    // for reps > 5 so we have no data to test it against..
+    // test('testing a effective 1RM for 5 <= reps < 10', () {
+    //   var testWeightAndRepRanges = [
+    //     {'weight': 100, 'reps': 5, 'expected': 112.5},
+    //     {'weight': 100, 'reps': 6, 'expected': 116.1},
+    //     {'weight': 100, 'reps': 7, 'expected': 120},
+    //     {'weight': 100, 'reps': 8, 'expected': 124.2},
+    //     {'weight': 100, 'reps': 9, 'expected': 128.8},
+    //
+    //     {'weight': 55, 'reps': 5, 'expected': 61.9},
+    //     {'weight': 55, 'reps': 6, 'expected': 63.9},
+    //     {'weight': 55, 'reps': 7, 'expected': 66},
+    //     {'weight': 55, 'reps': 8, 'expected': 68.3},
+    //     {'weight': 55, 'reps': 9, 'expected': 70.8},
+    //   ];
+    //
+    //   for (var test in testWeightAndRepRanges) {
+    //     double result = Estimated1RMUtils.calculateEstimated1RM(test['weight']!.toDouble(), test['reps']!.toInt())!;
+    //     double roundedResult = double.parse(result.toStringAsFixed(1));
+    //
+    //     expect(roundedResult, test['expected']!.toDouble());
+    //   }
+    // });
+    test('return null for reps == null || weight == null', () {
+      expect(Estimated1RMUtils.calculateEstimated1RM(1, null), isNull);
+      expect(Estimated1RMUtils.calculateEstimated1RM(null, 1), isNull);
+      expect(Estimated1RMUtils.calculateEstimated1RM(null, null), isNull);
+    });
+  });
+  group('returnEstimated1RM', () {
+    test('returns correctly formatted 1RM', () {});
+  });
+
+  // Calc weight from 1RM
+  group('calculateWeightFrom1RM', () {
+    test('testing calculated weight from 1RM with reps < 5', () {
+      var test1RMAndRepRanges = [
+        {'expected': 100, 'reps': 1, '1RM': 100},
+        {'expected': 50, 'reps': 1, '1RM': 50},
+        {'expected': 33, 'reps': 1, '1RM': 33},
+        {'expected': 1.5, 'reps': 1, '1RM': 1.5},
+        {'expected': 100, 'reps': 2, '1RM': 102.9},
+        {'expected': 100, 'reps': 3, '1RM': 105.9},
+        {'expected': 100, 'reps': 4, '1RM': 109.1},
+        {'expected': 55, 'reps': 2, '1RM': 56.6},
+        {'expected': 55, 'reps': 3, '1RM': 58.2},
+        {'expected': 55, 'reps': 4, '1RM': 60},
+      ];
+
+      for (var test in test1RMAndRepRanges) {
+        double result = Estimated1RMUtils.calculateWeightFrom1RM(
+            test['reps']!.toInt(), test['1RM']!.toDouble());
+        double roundedResult = double.parse(result.toStringAsFixed(1));
+
+        expect(roundedResult, test['expected']!.toDouble());
+      }
+    });
+  });
+  group('returnCalculatedWeightFrom1RM', () {});
+
+  // Calc reps from 1RM
+  group('calculateRepsFrom1RM', () {
+    test('testing calculated reps from 1RM with weight < 5', () {
+      var test1RMAndWeightRanges = [
+        {'weight': 100, 'expected': 1, '1RM': 100},
+        {'weight': 50, 'expected': 1, '1RM': 50},
+        {'weight': 33, 'expected': 1, '1RM': 33},
+        {'weight': 1.5, 'expected': 1, '1RM': 1.5},
+        {'weight': 100, 'expected': 2, '1RM': 102.9},
+        {'weight': 100, 'expected': 3, '1RM': 105.9},
+        {'weight': 100, 'expected': 4, '1RM': 109.1},
+        {'weight': 55, 'expected': 2, '1RM': 56.6},
+        {'weight': 55, 'expected': 3, '1RM': 58.2},
+        {'weight': 55, 'expected': 4, '1RM': 60},
+      ];
+
+      for (var test in test1RMAndWeightRanges) {
+        double result = Estimated1RMUtils.calculateRepsFrom1RM(
+            test['weight']!.toDouble(), test['1RM']!.toDouble());
+        double roundedResult = double.parse(result.toStringAsFixed(1));
+
+        expect(roundedResult, test['expected']!.toDouble());
+      }
+    });
+  });
+  group('returnCalculatedRepsFrom1RM', () {});
+}

--- a/test/constants/utils/estimated_1RM_utils_test.dart
+++ b/test/constants/utils/estimated_1RM_utils_test.dart
@@ -191,6 +191,8 @@ void main() {
         {'weight': 55, 'expected': 2, '1RM': 56.6},
         {'weight': 55, 'expected': 3, '1RM': 58.2},
         {'weight': 55, 'expected': 4, '1RM': 60},
+         // Placeholder to test live anomalies
+        // {'weight': 1, 'expected': 2, '1RM': 12},
       ];
 
       for (var test in test1RMAndWeightRanges) {


### PR DESCRIPTION
## The Plan:
The Initial Idea of this change was to allow clearer comparison of sets across different weights, by measuring all working sets against the metric of the estimated (or actual) 1 Rep Max (1RM).
This allowed a user to work with a lower weight and still be able to compare their performance to the comparison set, allowing for progressive overload.

Later this idea expanded into additionally estimating either the sets, or weight required to match the comparison set's estimated 1RM, so that if the user just enters in a weight, the required number of reps to match the comparison set's Estimated 1RM will be shown in the reps text box, and vice versa

### Before and After
| Previous Layout | Current Layout |
|--------|--------|
| <img alt="Screenshot 2025-02-17 at 15 04 47" src="https://github.com/user-attachments/assets/9adc4298-6d54-456f-88b6-dcbc5c8cb9a9" /> |<img alt="Screenshot 2025-02-17 at 15 03 48" src="https://github.com/user-attachments/assets/7f895d1c-01de-4945-ad73-06e49cffe3b7" /> |

### Functionality of estimating 1RM
| Estimated 1RM | Estimated required reps | Estimated required weight |
|--------|--------|--------|
| <img alt="Screenshot 2025-02-17 at 15 03 48" src="https://github.com/user-attachments/assets/7f895d1c-01de-4945-ad73-06e49cffe3b7" /> | <img alt="Screenshot 2025-02-17 at 15 08 20" src="https://github.com/user-attachments/assets/406f6a78-acc8-4926-9c48-15e7873510b3" /> | <img alt="Screenshot 2025-02-17 at 15 09 07" src="https://github.com/user-attachments/assets/0ca5ab72-4762-43a6-a86b-3dd88eb8d8c2" /> |
| Showing Estimated 1RM from entered weight and reps, **background yellow** | Showing estimated **required reps** to match comparison set's estimated 1RM with the entered weight, **background black** | Showing estimated **required weight** to match comparison set's estimated 1RM with the entered number of reps, **background black** |

## Summary Changes Made:
- A utility class `Estimated1RMUtils` was created and put into a new `utils` directory under `lib/constants/utils`.
This class houses all of the new functionality for calculating and formatting the estimated 1RM, weight and reps, along with the conditions on which to show these values.
- Added tests for the `Estimated1RMUtils` class
- updated add exercise state to use a more granular `copyWith` method, to allow entering `null` values without the method taking the value as `not set` - meaning that values can be removed from the `CurrentSet` after being entered
- Added the estimated 1RM column to the sets row
- Added hint text to both the `weight` and `reps` column in the sets row, to show the calculated values when conditions are met
- Set the actual estimated 1RM (when both weight and reps either have been written (in the case of completed sets) or have been entered in) to have a black background and when a rep or weight suggestion is made the background is yellow, to indicate clearly
- moved the enums `SetType` and `TextFieldType` definitions into the `enums` file (`lib/constants/enums`)

